### PR TITLE
Fix test for bad.php expecting 2 errors at line 448 [2890239]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 sudo: false
 

--- a/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
+++ b/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
@@ -287,7 +287,7 @@ class Drupal_BadUnitTest extends CoderSniffUnitTest
                         436 => 1,
                         438 => 1,
                         443 => 1,
-                        448 => 2,
+                        448 => 1,
                         452 => 1,
                         495 => 1,
                         504 => 1,


### PR DESCRIPTION
Recent change to `Squiz.WhiteSpace.FunctionSpacing` no longer records violations at line 448 of `bad.php` in `Drupal_BadUnitTest`. See PHP_CodeSniffer 2.9.1 release notes at:

https://github.com/squizlabs/PHP_CodeSniffer/blob/2.9.1/package.xml#L2503

## Related Issues

See https://www.drupal.org/node/2890239