### PR TITLE
Remove older and unsupported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "keywords": ["phpcs", "standards", "code review"],
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "ext-mbstring": "*",
         "squizlabs/php_codesniffer": "^3.0.1",
         "symfony/yaml": ">=2.0.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.6.0",
         "ext-mbstring": "*",
-        "squizlabs/php_codesniffer": "^3.0.1",
+        "squizlabs/php_codesniffer": "^3.0.1 <4.0",
         "symfony/yaml": ">=2.0.0"
     },
     "autoload": {


### PR DESCRIPTION
https://www.drupal.org/project/coder/issues/3002772

> I recommend removing unsupported PHP version for the Drupal part such as PHP 5.4 and 5.5.
> 
> I know it is published an explanation on https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.0.0a1
> 
> However, please give your opinion here if we should still keep PHP 5.4 and 5.5. Since I am trying to follow https://www.drupal.org/docs/8/system-requirements/php-requirements