### PR TITLE
Gender neutral comment sniff

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
@@ -1,38 +1,33 @@
 <?php
 /**
- * PHP_CodeSniffer_Sniffs_Drupal_Commenting_InlineCommentSniff.
- *
- * PHP version 5
+ * Parses and verifies comment language.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
+
+namespace Drupal\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * PHP_CodeSniffer_Sniffs_Drupal_Sniffs_Commenting_GenderNeutralCommentSniff.
- *
- * Checks that gender specific language does not appear in comments.
+ * Parses and verifies that comments use gender neutral language.
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Drupal_Sniffs_Commenting_GenderNeutralCommentSniff implements PHP_CodeSniffer_Sniff
+class GenderNeutralCommentSniff implements Sniff
 {
 
-    protected $error = 'Unnecessarily gendered language in a comment';
-
     /**
-     * A list of tokenizers this sniff supports.
+     * The error message.
      *
-     * @var array
+     * @var string
      */
-    public $supportedTokenizers = array(
-                                   'PHP',
-                                   'JS',
-                                  );
-
+    protected $error = 'Unnecessarily gendered language in a comment';
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -52,13 +47,13 @@ class Drupal_Sniffs_Commenting_GenderNeutralCommentSniff implements PHP_CodeSnif
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -80,18 +75,18 @@ class Drupal_Sniffs_Commenting_GenderNeutralCommentSniff implements PHP_CodeSnif
     /**
      * Checks the indentation level of the comment contents.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     * @param string               $comment   The comment to be checked.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     * @param string                      $comment   The comment to be checked.
      *
      * @return void
      */
-    protected function checkComment(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $comment) {
+    protected function checkComment(File $phpcsFile, $stackPtr, $comment) {
         if (preg_match('/(^|\W)(he|she|him|his|her|hers)($|\W)/i', $comment)) {
             $warning = 'Unnecessarily gendered language in a comment';
             $phpcsFile->addError($warning, $stackPtr, 'GenderNeutral');
         }
-    }
+    }//end checkComment()
 
 }//end class

--- a/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
@@ -50,7 +50,7 @@ class GenderNeutralCommentSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        if ((bool) preg_match('/(^|\W)(he|she|him|his|her|hers)($|\W)/i', $tokens[$stackPtr]['content']) === true) {
+        if ((bool) preg_match('/(^|\W)(he|her|hers|him|his|she)($|\W)/i', $tokens[$stackPtr]['content']) === true) {
             $phpcsFile->addError('Unnecessarily gendered language in a comment', $stackPtr, 'GenderNeutral');
         }
 

--- a/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHP_CodeSniffer_Sniffs_Drupal_Commenting_InlineCommentSniff.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * PHP_CodeSniffer_Sniffs_Drupal_Sniffs_Commenting_GenderNeutralCommentSniff.
+ *
+ * Checks that gender specific language does not appear in comments.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Drupal_Sniffs_Commenting_GenderNeutralCommentSniff implements PHP_CodeSniffer_Sniff
+{
+
+    protected $error = 'Unnecessarily gendered language in a comment';
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+                                   'PHP',
+                                   'JS',
+                                  );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_COMMENT,
+                T_DOC_COMMENT_OPEN_TAG,
+               );
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_COMMENT) {
+            $this->checkComment($phpcsFile, $stackPtr, $tokens[$stackPtr]['content']);
+        }
+        elseif ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+            $commentEnd = $tokens[$stackPtr]['comment_closer'];
+            for ($i = $stackPtr; $i < $commentEnd; $i++) {
+                if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                    $this->checkComment($phpcsFile, $i, $tokens[$i]['content']);
+                }
+            }
+        }
+
+
+    }//end process()
+
+    /**
+     * Checks the indentation level of the comment contents.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     * @param string               $comment   The comment to be checked.
+     *
+     * @return void
+     */
+    protected function checkComment(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $comment) {
+        if (preg_match('/(^|\W)(he|she|him|his|her|hers)($|\W)/i', $comment)) {
+            $warning = 'Unnecessarily gendered language in a comment';
+            $phpcsFile->addError($warning, $stackPtr, 'GenderNeutral');
+        }
+    }
+
+}//end class

--- a/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
@@ -23,13 +23,6 @@ class GenderNeutralCommentSniff implements Sniff
 {
 
     /**
-     * The error message.
-     *
-     * @var string
-     */
-    protected $error = 'Unnecessarily gendered language in a comment';
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -38,7 +31,7 @@ class GenderNeutralCommentSniff implements Sniff
     {
         return array(
                 T_COMMENT,
-                T_DOC_COMMENT_OPEN_TAG,
+                T_DOC_COMMENT_STRING,
                );
 
     }//end register()
@@ -56,37 +49,10 @@ class GenderNeutralCommentSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-
-        if ($tokens[$stackPtr]['code'] === T_COMMENT) {
-            $this->checkComment($phpcsFile, $stackPtr, $tokens[$stackPtr]['content']);
+        if (preg_match('/(^|\W)(he|she|him|his|her|hers)($|\W)/i', $tokens[$stackPtr]['content'])) {
+            $phpcsFile->addError('Unnecessarily gendered language in a comment', $stackPtr, 'GenderNeutral');
         }
-        elseif ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
-            $commentEnd = $tokens[$stackPtr]['comment_closer'];
-            for ($i = $stackPtr; $i < $commentEnd; $i++) {
-                if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                    $this->checkComment($phpcsFile, $i, $tokens[$i]['content']);
-                }
-            }
-        }
-
 
     }//end process()
-
-    /**
-     * Checks the indentation level of the comment contents.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token
-     *                                               in the stack passed in $tokens.
-     * @param string                      $comment   The comment to be checked.
-     *
-     * @return void
-     */
-    protected function checkComment(File $phpcsFile, $stackPtr, $comment) {
-        if (preg_match('/(^|\W)(he|she|him|his|her|hers)($|\W)/i', $comment)) {
-            $warning = 'Unnecessarily gendered language in a comment';
-            $phpcsFile->addError($warning, $stackPtr, 'GenderNeutral');
-        }
-    }//end checkComment()
 
 }//end class

--- a/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/GenderNeutralCommentSniff.php
@@ -22,6 +22,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class GenderNeutralCommentSniff implements Sniff
 {
 
+
     /**
      * Returns an array of tokens this test wants to listen for.
      *
@@ -49,10 +50,11 @@ class GenderNeutralCommentSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        if (preg_match('/(^|\W)(he|she|him|his|her|hers)($|\W)/i', $tokens[$stackPtr]['content'])) {
+        if ((bool) preg_match('/(^|\W)(he|she|him|his|her|hers)($|\W)/i', $tokens[$stackPtr]['content']) === true) {
             $phpcsFile->addError('Unnecessarily gendered language in a comment', $stackPtr, 'GenderNeutral');
         }
 
     }//end process()
+
 
 }//end class

--- a/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc
@@ -29,4 +29,6 @@
  */
 function example() {
   // They looked at him.
+  // The sniff only checked comments not code.
+  $a = "The regex finds he, her, hers, him, his and she.";
 }

--- a/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Example gendered comments.
+ *
+ * He did something.
+ * She did something.
+ * They did something.
+ */
+
+// She wrote this comment.
+// He wrote this comment.
+// S/he wrote this comment.
+// They wrote this comment.
+// His foot moved.
+// Her foot moved.
+// Their foot moved.
+// He's got a foot.
+// She's got a foot.
+// Hers is blue.
+// His is blue.
+/**
+ * Test function.
+ *
+ * He did something.
+ * She did something.
+ * They did something.
+ */
+function example() {
+  // They looked at him.
+}

--- a/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc.fixed
@@ -29,4 +29,6 @@
  */
 function example() {
   // They looked at him.
+  // The sniff only checked comments not code.
+  $a = "The regex finds he, her, hers, him, his and she.";
 }

--- a/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.inc.fixed
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Example gendered comments.
+ *
+ * He did something.
+ * She did something.
+ * They did something.
+ */
+
+// She wrote this comment.
+// He wrote this comment.
+// S/he wrote this comment.
+// They wrote this comment.
+// His foot moved.
+// Her foot moved.
+// Their foot moved.
+// He's got a foot.
+// She's got a foot.
+// Hers is blue.
+// His is blue.
+/**
+ * Test function.
+ *
+ * He did something.
+ * She did something.
+ * They did something.
+ */
+function example() {
+  // They looked at him.
+}

--- a/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.php
@@ -1,6 +1,10 @@
 <?php
 
-class Drupal_Sniffs_Commenting_GenderNeutralCommentUnitTest extends CoderSniffUnitTest
+namespace Drupal\Sniffs\Commenting;
+
+use Drupal\Test\CoderSniffUnitTest;
+
+class GenderNeutralCommentUnitTest extends CoderSniffUnitTest
 {
 
     /**
@@ -11,7 +15,7 @@ class Drupal_Sniffs_Commenting_GenderNeutralCommentUnitTest extends CoderSniffUn
      *
      * @return array(int => int)
      */
-    public function getErrorList($testFile)
+    public function getErrorList($testFile = NULL)
     {
         return array(
             7 => 1,
@@ -41,7 +45,7 @@ class Drupal_Sniffs_Commenting_GenderNeutralCommentUnitTest extends CoderSniffUn
      *
      * @return array(int => int)
      */
-    public function getWarningList($testFile)
+    public function getWarningList($testFile = NULL)
     {
         return array(
                );

--- a/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+class Drupal_Sniffs_Commenting_GenderNeutralCommentUnitTest extends CoderSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getErrorList($testFile)
+    {
+        return array(
+            7 => 1,
+            8 => 1,
+            12 => 1,
+            13 => 1,
+            14 => 1,
+            16 => 1,
+            17 => 1,
+            19 => 1,
+            20 => 1,
+            21 => 1,
+            22 => 1,
+            26 => 1,
+            27 => 1,
+            31 => 1,
+           );
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getWarningList($testFile)
+    {
+        return array(
+               );
+
+    }//end getWarningList()
+
+
+}//end class

--- a/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/GenderNeutralCommentUnitTest.php
@@ -7,6 +7,7 @@ use Drupal\Test\CoderSniffUnitTest;
 class GenderNeutralCommentUnitTest extends CoderSniffUnitTest
 {
 
+
     /**
      * Returns the lines where errors should occur.
      *

--- a/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
+++ b/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
@@ -371,7 +371,8 @@ class BadUnitTest extends CoderSniffUnitTest
                         815 => 1,
                         820 => 1,
                         827 => 1,
-                        833 => 2,
+                        829 => 1,
+                        835 => 2,
                        );
         }
         return array();

--- a/coder_sniffer/Drupal/Test/bad/bad.php
+++ b/coder_sniffer/Drupal/Test/bad/bad.php
@@ -825,6 +825,8 @@ t("");
 
 /**
  * Doc comment with a white space at the end. 
+ *
+ * He made a gendered comment.
  */
 function test28() {
 

--- a/coder_sniffer/Drupal/Test/bad/bad.php.fixed
+++ b/coder_sniffer/Drupal/Test/bad/bad.php.fixed
@@ -872,6 +872,8 @@ t("");
 
 /**
  * Doc comment with a white space at the end.
+ *
+ * He made a gendered comment.
  */
 function test28() {
 


### PR DESCRIPTION
# Problem/Motivation
Drupal core has plenty of comments with unnecessary use of gender. For example:

```
     // If we are performing a non-interactive installation. If only one language
     // (English) is available, assume the user knows what he is doing. Otherwise
     // throw an error.
```

# Proposed resolution
Add a sniff to prevent this from happening.

See https://www.drupal.org/project/coder/issues/3021632
