### PR TITLE
False positive for array spans longer than 80 characters

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Arrays/ArraySniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Arrays/ArraySniff.php
@@ -101,16 +101,19 @@ class ArraySniff implements Sniff
         }
 
         if ($isInlineArray === true) {
-            // Check if this array contains at least 3 elements and exceeds the 80
-            // character line length.
+            // Check if this array specifies keys, contains at least 3 elements,
+            // and exceeds the 80 character line length.
             if ($tokens[$tokens[$stackPtr][$parenthesis_closer]]['column'] > 80) {
-                $comma1 = $phpcsFile->findNext(T_COMMA, ($stackPtr + 1), $tokens[$stackPtr][$parenthesis_closer]);
-                if ($comma1 !== false) {
-                    $comma2 = $phpcsFile->findNext(T_COMMA, ($comma1 + 1), $tokens[$stackPtr][$parenthesis_closer]);
-                    if ($comma2 !== false) {
-                        $error = 'If the line declaring an array spans longer than 80 characters, each element should be broken into its own line';
-                        $phpcsFile->addError($error, $stackPtr, 'LongLineDeclaration');
-                    }
+                $doubleArrow = $phpcsFile->findNext(T_DOUBLE_ARROW, ($stackPtr + 1), $tokens[$stackPtr][$parenthesis_closer]);
+                if ($doubleArrow !== false) {
+                  $comma1 = $phpcsFile->findNext(T_COMMA, ($stackPtr + 1), $tokens[$stackPtr][$parenthesis_closer]);
+                  if ($comma1 !== false) {
+                      $comma2 = $phpcsFile->findNext(T_COMMA, ($comma1 + 1), $tokens[$stackPtr][$parenthesis_closer]);
+                      if ($comma2 !== false) {
+                          $error = 'If the line declaring an array spans longer than 80 characters, each element should be broken into its own line';
+                          $phpcsFile->addError($error, $stackPtr, 'LongLineDeclaration');
+                      }
+                  }
                 }
             }
 


### PR DESCRIPTION
See https://www.drupal.org/project/coder/issues/1805542

## Problem / Motivation
I'm encountering this warning in two instances:

1. In a complex form, I'm altering `#parents` to remove wrapping elements from the structure of submitted values in form state. The array goes over 80 characters on the line, but breaking it into individual lines is awkward for this type of simple definition.
   ```
          $form[$policyTypeKey]['directives'][$directiveName]['options']['flags_wrapper']['flags'] = [
            '#type' => 'checkboxes',
            '#parents' => [$policyTypeKey, 'directives', $directiveName, 'flags'],
            '#options' => [
              'unsafe-inline' => "'unsafe-inline'",
              'unsafe-eval' => "'unsafe-eval'",
              'unsafe-hashes' => "'unsafe-hashes'",
              'unsafe-allow-redirects' => "'unsafe-allow-redirects'",
              'strict-dynamic' => "'strict-dynamic'",
              'report-sample' => "'report-sample'",

            ],
            '#default_value' => $config->get($policyTypeKey . '.directives.' . $directiveName . '.flags') ?: [],
          ];
   ```

2. Later when retrieving the form values during validation or submission, they are accessed by specifying the keys in an array which will be longer than 80 characters.
    ```
    $reportHandlerOptions = $form_state->getValue([$policyTypeKey, 'reporting', $reportHandlerPluginId]);
    ```

## Proposed Resolution
This PR adds a requirement to the warning that the array assigns at least one key as well.

e.g.
This would not produce a warning:

    $variable = ['a', 'really', 'long', 'array', 'that', 'is', 'longer', 'than', 80, 'characters'];

However this would have a warning:

    $variable = [1 => 'a', 'really', 'long', 'array', 'that', 'is', 'longer', 'than', 80, 'characters'];
