### PR TITLE
tests(phpcs): Update PHPCS to 3.4.1 and fix phpunit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: xenial
+# For PHP 5.5 and lower testing we need to stick to Ubuntu 14.04.
+dist: trusty
 language: php
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
   directories:
     - $HOME/.composer/cache
     - vendor
-    - composer.lock
 
 matrix:
   fast_finish: true
@@ -26,10 +25,9 @@ before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
 before_script:
-  # Run install in case the cached vendor directory is not present.
+  # Running composer install without a lock file will also update cached
+  # dependencies in vendor.
   - composer install
-  # Always run tests with up to date dependencies.
-  - composer update
 
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
-dist: trusty
+dist: xenial
 language: php
 sudo: false
+
+# Cache composer downloads to speed up the composer install step.
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 matrix:
   fast_finish: true
@@ -11,20 +16,11 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: 7.2
-    - php: nightly
-    - php: hhvm
-
-  allow_failures:
-    - php: hhvm
-    - php: nightly
+    - php: 7.3
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-  # Circumvent a bug in the travis HHVM image - ships with incompatible PHPUnit.
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer self-update; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:~4.0; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer install; fi
 
 before_script:
   # We don't have a composer.lock file because we always want to test with

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ dist: trusty
 language: php
 sudo: false
 
-# Cache composer downloads to speed up the composer install step.
+# Cache composer vendor directories to speed up the composer install step.
 cache:
   directories:
     - $HOME/.composer/cache
+    - vendor
+    - composer.lock
 
 matrix:
   fast_finish: true
@@ -24,9 +26,10 @@ before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
 before_script:
-  # We don't have a composer.lock file because we always want to test with
-  # latest dependencies.
+  # Run install in case the cached vendor directory is not present.
   - composer install
+  # Always run tests with up to date dependencies.
+  - composer update
 
 script:
   - ./vendor/bin/phpunit

--- a/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
+++ b/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
@@ -32,7 +32,7 @@ class BadUnitTest extends CoderSniffUnitTest
                         3 => 2,
                         4 => 1,
                         5 => 1,
-                        6 => 2,
+                        6 => 1,
                         7 => 1,
                         8 => 1,
                         9 => 1,

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "ext-mbstring": "*",
-        "squizlabs/php_codesniffer": "^3.0.1",
+        "squizlabs/php_codesniffer": "dev-master#8c8c4ff2566630e79c52278ceb6e383795c9f443",
         "symfony/yaml": ">=2.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "ext-mbstring": "*",
-        "squizlabs/php_codesniffer": "dev-master#8c8c4ff2566630e79c52278ceb6e383795c9f443",
+        "squizlabs/php_codesniffer": ">=3.4.1",
         "symfony/yaml": ">=2.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "ext-mbstring": "*",
-        "squizlabs/php_codesniffer": ">=3.4.1",
+        "squizlabs/php_codesniffer": "^3.4.1",
         "symfony/yaml": ">=2.0.0"
     },
     "autoload": {


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3040784

PHPIUnit tests are broken, if we update PHPCS then they are fixed again.

This is wasting resources because a git clone of PHP_CodeSniffer is 200MB, so I will open an issue there that they should release 3.4.1