### PR TITLE
feat(HookComment): Check hook implementation comments if they repeat the function name

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/HookCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/HookCommentSniff.php
@@ -111,7 +111,21 @@ class HookCommentSniff implements Sniff
                     }
                 }
             }//end if
+
+            return;
         }//end if
+
+        // Check if the doc block just repeats the function name with
+        // "Implements example_hook_name()".
+        $functionName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($functionName !== null && preg_match("/^[\s]*Implements $functionName\(\)\.$/i", $shortContent) === 1) {
+            $error = 'Hook implementations must be documented with "Implements hook_example()."';
+            $fix   = $phpcsFile->addFixableError($error, $short, 'HookRepeat');
+            if ($fix === true) {
+                $newComment = preg_replace('/Implements [^_]+/', 'Implements hook', $shortContent);
+                $phpcsFile->fixer->replaceToken($short, $newComment);
+            }
+        }
 
     }//end process()
 

--- a/coder_sniffer/Drupal/Test/Commenting/HookCommentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/HookCommentUnitTest.inc
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Example file with hook implementations.
+ */
+
+/**
+ * Implements example_page_build().
+ */
+function example_page_build(&$page) {
+}

--- a/coder_sniffer/Drupal/Test/Commenting/HookCommentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/HookCommentUnitTest.inc.fixed
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Example file with hook implementations.
+ */
+
+/**
+ * Implements hook_page_build().
+ */
+function example_page_build(&$page) {
+}

--- a/coder_sniffer/Drupal/Test/Commenting/HookCommentUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/HookCommentUnitTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\Sniffs\Commenting;
+
+use Drupal\Test\CoderSniffUnitTest;
+
+class HookCommentUnitTest extends CoderSniffUnitTest
+{
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getErrorList($testFile = NULL)
+    {
+        return array(
+                9 => 1,
+               );
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getWarningList($testFile = NULL)
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Code like this:

```php
/**
 * Implements example_page_build().
 */
function example_page_build(&$page) {
}
```
should be fixed to
```php
/**
 * Implements hook_page_build().
 */
function example_page_build(&$page) {
}
```