### PR TITLE
Underscore separation is allowed for plugin annotation class properties

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -63,22 +63,27 @@ class ValidVariableNameSniff extends AbstractVariableSniff
                 return;
             }
 
-          // Plugin annotations may have underscores in class properties.
-          // For example, see \Drupal\Core\Field\Annotation\FieldFormatter.
-          // The only class named "Plugin" in Drupal core is
-          // \Drupal\Component\Annotation\Plugin while many Views plugins
-          // extend \Drupal\views\Annotation\ViewsPluginAnnotationBase.
-          if ($extendsName !== FALSE && in_array($extendsName, [
-              'Plugin',
-              'ViewsPluginAnnotationBase',
-            ])) {
-            return;
-          }
-          $implementsNames = $phpcsFile->findImplementedInterfaceNames($classPtr);
-          if ($implementsNames !== FALSE && in_array('AnnotationInterface', $implementsNames)) {
-            return;
-          }
-        }
+            // Plugin annotations may have underscores in class properties.
+            // For example, see \Drupal\Core\Field\Annotation\FieldFormatter.
+            // The only class named "Plugin" in Drupal core is
+            // \Drupal\Component\Annotation\Plugin while many Views plugins
+            // extend \Drupal\views\Annotation\ViewsPluginAnnotationBase.
+            if ($extendsName !== true && in_array(
+                $extendsName,
+                [
+                 'Plugin',
+                 'ViewsPluginAnnotationBase',
+                ]
+            ) !== false
+            ) {
+                return;
+            }
+
+            $implementsNames = $phpcsFile->findImplementedInterfaceNames($classPtr);
+            if ($implementsNames !== true && in_array('AnnotationInterface', $implementsNames) !== false) {
+                return;
+            }
+        }//end if
 
         $error = 'Class property %s should use lowerCamel naming without underscores';
         $data  = array($tokens[$stackPtr]['content']);

--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -62,6 +62,22 @@ class ValidVariableNameSniff extends AbstractVariableSniff
             if ($extendsName !== false && strpos($extendsName, 'ConfigEntity') !== false) {
                 return;
             }
+
+          // Plugin annotations may have underscores in class properties.
+          // For example, see \Drupal\Core\Field\Annotation\FieldFormatter.
+          // The only class named "Plugin" in Drupal core is
+          // \Drupal\Component\Annotation\Plugin while many Views plugins
+          // extend \Drupal\views\Annotation\ViewsPluginAnnotationBase.
+          if ($extendsName !== FALSE && in_array($extendsName, [
+              'Plugin',
+              'ViewsPluginAnnotationBase',
+            ])) {
+            return;
+          }
+          $implementsNames = $phpcsFile->findImplementedInterfaceNames($classPtr);
+          if ($implementsNames !== FALSE && in_array('AnnotationInterface', $implementsNames)) {
+            return;
+          }
         }
 
         $error = 'Class property %s should use lowerCamel naming without underscores';

--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -68,7 +68,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
             // The only class named "Plugin" in Drupal core is
             // \Drupal\Component\Annotation\Plugin while many Views plugins
             // extend \Drupal\views\Annotation\ViewsPluginAnnotationBase.
-            if ($extendsName !== true && in_array(
+            if ($extendsName !== false && in_array(
                 $extendsName,
                 [
                  'Plugin',
@@ -80,7 +80,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
             }
 
             $implementsNames = $phpcsFile->findImplementedInterfaceNames($classPtr);
-            if ($implementsNames !== true && in_array('AnnotationInterface', $implementsNames) !== false) {
+            if ($implementsNames !== false && in_array('AnnotationInterface', $implementsNames) !== false) {
                 return;
             }
         }//end if

--- a/coder_sniffer/Drupal/Test/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/NamingConventions/ValidVariableNameUnitTest.inc
@@ -24,3 +24,14 @@ class TestAnnotationProperties2 extends ViewsPluginAnnotationBase {
   public $entity_type;
 
 }
+
+class TestAnnotationProperties3 implements AnnotationInterface {
+
+  /**
+   * The entity_type.
+   *
+   * @var string
+   */
+  public $entity_type;
+
+}

--- a/coder_sniffer/Drupal/Test/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/NamingConventions/ValidVariableNameUnitTest.inc
@@ -2,3 +2,25 @@
 
 $UppperCamelName = 0;
 $lowerCamelName = 1;
+
+class TestAnnotationProperties extends Plugin {
+
+  /**
+   * The entity_type.
+   *
+   * @var string
+   */
+  public $entity_type;
+
+}
+
+class TestAnnotationProperties2 extends ViewsPluginAnnotationBase {
+
+  /**
+   * The entity_type.
+   *
+   * @var string
+   */
+  public $entity_type;
+
+}


### PR DESCRIPTION
PR for issue https://www.drupal.org/project/coder/issues/2804739.

