### PR TITLE
Add a DrupalPractice rule for $strictConfigSchema in tests

### DIFF
--- a/coder_sniffer/DrupalPractice/Sniffs/Objects/StrictSchemaDisabledSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Objects/StrictSchemaDisabledSniff.php
@@ -79,14 +79,9 @@ class StrictSchemaDisabledSniff extends AbstractVariableSniff
     protected function isTestClass(File $phpcsFile, $stackPtr)
     {
         // Only applies to test classes, which have Test in the name.
-        $types  = array(
-                   T_CLASS,
-                   T_TRAIT,
-                  );
-        $class  = $phpcsFile->findPrevious($types, ($stackPtr - 1));
-        $name   = $phpcsFile->findNext([T_STRING], $class);
-        $tokens = $phpcsFile->getTokens();
-
+        $tokens   = $phpcsFile->getTokens();
+        $classPtr = key($tokens[$stackPtr]['conditions']);
+        $name     = $phpcsFile->findNext([T_STRING], $classPtr);
         return strpos($tokens[$name]['content'], 'Test') !== false;
 
     }//end isTestClass()

--- a/coder_sniffer/DrupalPractice/Sniffs/Objects/StrictSchemaDisabledSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Objects/StrictSchemaDisabledSniff.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * DrupalPractice_Sniffs_Objects_StrictSchemaDisabledSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace DrupalPractice\Sniffs\Objects;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+
+/**
+ * Checks that $strictConfigSchema is not set to FALSE in test classes.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class StrictSchemaDisabledSniff extends AbstractVariableSniff
+{
+
+    /**
+     * The name of the variable in the test base class to disable config schema checking.
+     */
+    const STRICT_CONFIG_SCHEMA_NAME = '$strictConfigSchema';
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function processMemberVar(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (($tokens[$stackPtr]['content'] === static::STRICT_CONFIG_SCHEMA_NAME) && ($this->isTestClass($phpcsFile, $stackPtr) === true)) {
+            $find = array(
+                     T_FALSE,
+                     T_TRUE,
+                     T_NULL,
+                     T_SEMICOLON,
+                    );
+            $next = $phpcsFile->findNext($find, ($stackPtr + 1));
+            // If this variable is being set, the only allowed value is TRUE.
+            // Otherwise if FALSE or NULL, schema checking is disabled.
+            if ($tokens[$next]['code'] !== T_TRUE) {
+                $error = 'Do not disable strict config schema checking in tests. Instead ensure your module properly declares its schema for configurations.';
+                $data  = [$tokens[$stackPtr]['content']];
+                $phpcsFile->addError(
+                    $error,
+                    $stackPtr,
+                    'StrictConfigSchema',
+                    $data
+                );
+            }
+        }//end if
+
+    }//end processMemberVar()
+
+
+    /**
+     * Determine if this class is a test class.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return bool
+     *   Returns TRUE if the current class is a test class.
+     */
+    protected function isTestClass(File $phpcsFile, $stackPtr)
+    {
+        // Only applies to test classes, which have Test in the name.
+        $types  = array(
+                   T_CLASS,
+                   T_TRAIT,
+                  );
+        $class  = $phpcsFile->findPrevious($types, ($stackPtr - 1));
+        $name   = $phpcsFile->findNext([T_STRING], $class);
+        $tokens = $phpcsFile->getTokens();
+
+        return strpos($tokens[$name]['content'], 'Test') !== false;
+
+    }//end isTestClass()
+
+
+    /**
+     * Called to process normal member vars.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
+     *                                               token was found.
+     * @param int                         $stackPtr  The position where the token was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return ($phpcsFile->numTokens + 1) to skip
+     *                  the rest of the file.
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr)
+    {
+
+    }//end processVariable()
+
+
+    /**
+     * Called to process variables found in double quoted strings or heredocs.
+     *
+     * Note that there may be more than one variable in the string, which will
+     * result only in one call for the string or one call per line for heredocs.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
+     *                                               token was found.
+     * @param int                         $stackPtr  The position where the double quoted
+     *                                               string was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return ($phpcsFile->numTokens + 1) to skip
+     *                  the rest of the file.
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr)
+    {
+
+    }//end processVariableInString()
+
+
+}//end class

--- a/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.inc
+++ b/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.inc
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test class with strict config schema checking disabled.
+ */
+class TestFalse {
+
+    /**
+     * Disable strict config checking during testing.
+     */
+    protected $strictConfigSchema = FALSE;
+}
+
+class TestNull {
+    protected $strictConfigSchema = NULL;
+
+    public function strictConfigSchema()
+    {
+        // This is ok because it's non-member variable.
+        $strictConfigSchema = FALSE;
+        return $strictConfigSchema;
+    }
+}
+
+class TestNoDefault {
+    protected $strictConfigSchema;
+}
+
+class NormalClass {
+
+    /**
+     * This is OK because it isn't a test class.
+     */
+    protected $stictConfigSchema = FALSE;
+
+}
+
+trait TestTrait {
+    protected $strictConfigSchema;
+}

--- a/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.inc
+++ b/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.inc
@@ -5,36 +5,39 @@
  */
 class TestFalse {
 
-    /**
-     * Disable strict config checking during testing.
-     */
-    protected $strictConfigSchema = FALSE;
+  /**
+   * Disable strict config checking during testing.
+   */
+  protected $strictConfigSchema = FALSE;
 }
 
 class TestNull {
-    protected $strictConfigSchema = NULL;
+  protected $strictConfigSchema = NULL;
 
-    public function strictConfigSchema()
-    {
-        // This is ok because it's non-member variable.
-        $strictConfigSchema = FALSE;
-        return $strictConfigSchema;
-    }
+  public function strictConfigSchema() {
+    // This is ok because it's non-member variable.
+    $strictConfigSchema = FALSE;
+    return $strictConfigSchema;
+  }
 }
 
 class TestNoDefault {
-    protected $strictConfigSchema;
+  protected $strictConfigSchema;
+}
+
+class TestMultipleVars {
+  protected $foo, $strictConfigSchema = FALSE, $bar;
 }
 
 class NormalClass {
 
-    /**
-     * This is OK because it isn't a test class.
-     */
-    protected $stictConfigSchema = FALSE;
+  /**
+   * This is OK because it isn't a test class.
+   */
+  protected $stictConfigSchema = FALSE;
 
 }
 
 trait TestTrait {
-    protected $strictConfigSchema;
+  protected $strictConfigSchema;
 }

--- a/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.php
+++ b/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.php
@@ -21,8 +21,9 @@ class StrictSchemaDisabledUnitTest extends CoderSniffUnitTest
         return array(
             11 => 1,
             15 => 1,
-            26 => 1,
-            39 => 1,
+            25 => 1,
+            29 => 1,
+            42 => 1,
         );
 
     }//end getErrorList()

--- a/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.php
+++ b/coder_sniffer/DrupalPractice/Test/Objects/StrictSchemaDisabledUnitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DrupalPractice\Sniffs\Objects;
+
+use Drupal\Test\CoderSniffUnitTest;
+
+class StrictSchemaDisabledUnitTest extends CoderSniffUnitTest
+{
+
+
+   /**
+    * Returns the lines where errors should occur.
+    *
+    * The key of the array should represent the line number and the value
+    * should represent the number of errors that should occur on that line.
+    *
+    * @return array(int => int)
+    */
+    protected function getErrorList($testFile = NULL)
+    {
+        return array(
+            11 => 1,
+            15 => 1,
+            26 => 1,
+            39 => 1,
+        );
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    protected function getWarningList($testFile = NULL)
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class

--- a/coder_sniffer/DrupalPractice/Test/good/good.php
+++ b/coder_sniffer/DrupalPractice/Test/good/good.php
@@ -167,3 +167,12 @@ class PrivateMethodTest {
     return array_filter(array(), [$this, 'usedAsCallback']);
   }
 }
+
+class StrictSchemaEnabled {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $strictConfigSchema = TRUE;
+
+}


### PR DESCRIPTION
This is the corresponding PR for https://www.drupal.org/project/coder/issues/2957116 and is now targeted against the 3.x branch.