### PR TITLE
chore(ScopeIndent): Sync upstream changes from PHPCS

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -935,7 +935,7 @@ class ScopeIndentSniff implements Sniff
             // If the line starts with "->" we assume this is an indented chained
             // method invocation, so we add one level of indentation.
             if ($checkToken !== null && $tokens[$checkToken]['code'] === T_OBJECT_OPERATOR) {
-                $exact = true;
+                $exact        = true;
                 $checkIndent += $this->indent;
             }
 

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -914,6 +914,17 @@ class ScopeIndentSniff implements Sniff
                 $checkIndent = (int) (ceil($checkIndent / $this->indent) * $this->indent);
             }
 
+            // Special case for ELSE statements that are not on the same
+            // line as the previous IF statements closing brace. They still need
+            // to have the same indent or it will break code after the block.
+            if ($checkToken !== null && $tokens[$checkToken]['code'] === T_ELSE) {
+                $exact = true;
+            }
+
+            if ($checkIndent === null) {
+                $checkIndent = $currentIndent;
+            }
+
             // If the line starts with "->" we assume this is an indented chained
             // method invocation, so we add one level of indentation.
             if ($checkToken !== null && $tokens[$checkToken]['code'] === T_OBJECT_OPERATOR) {
@@ -926,18 +937,6 @@ class ScopeIndentSniff implements Sniff
                 if ($content{0} === '*') {
                     $checkIndent += 1;
                 }
-            }
-
-
-            // Special case for ELSE statements that are not on the same
-            // line as the previous IF statements closing brace. They still need
-            // to have the same indent or it will break code after the block.
-            if ($checkToken !== null && $tokens[$checkToken]['code'] === T_ELSE) {
-                $exact = true;
-            }
-
-            if ($checkIndent === null) {
-                $checkIndent = $currentIndent;
             }
 
             /*

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -624,11 +624,7 @@ class ScopeIndentSniff implements Sniff
                 && $tokens[$checkToken]['scope_closer'] === $checkToken
                 && $tokens[$checkToken]['line'] !== $tokens[$tokens[$checkToken]['scope_opener']]['line']))
                 || ($checkToken === null
-                && isset($openScopes[$i]) === true
-                || (isset($tokens[$i]['scope_condition']) === true
-                && isset($tokens[$i]['scope_closer']) === true
-                && $tokens[$i]['scope_closer'] === $i
-                && $tokens[$i]['line'] !== $tokens[$tokens[$i]['scope_opener']]['line']))
+                && isset($openScopes[$i]) === true)
             ) {
                 if ($this->debug === true) {
                     if ($checkToken === null) {

--- a/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc
@@ -125,3 +125,81 @@ function entity_permissions($entity_type_id, $operation) {
   }
   return [];
 }
+
+$tests = [
+  [
+    'original' => '$no_index_value_scalar = TRUE;',
+    'settings' => [
+      'no_index_value_scalar' => (object) [
+        'value' => FALSE,
+        'comment' => 'comment',
+      ],
+    ],
+    'expected' => '$no_index_value_scalar = false; // comment',
+  ],
+  [
+    'original' => '$no_index_value_scalar = TRUE;',
+    'settings' => [
+      'no_index_value_foo' => [
+        'foo' => [
+          'value' => (object) [
+            'value' => NULL,
+            'required' => TRUE,
+            'comment' => 'comment',
+          ],
+        ],
+      ],
+    ],
+    'expected' => <<<'EXPECTED'
+$no_index_value_scalar = TRUE;
+$no_index_value_foo['foo']['value'] = NULL; // comment
+EXPECTED
+  ],
+  [
+    'original' => '$no_index_value_array = array("old" => "value");',
+    'settings' => [
+      'no_index_value_array' => (object) [
+        'value' => FALSE,
+        'required' => TRUE,
+        'comment' => 'comment',
+      ],
+    ],
+    'expected' => '$no_index_value_array = array("old" => "value");
+$no_index_value_array = false; // comment',
+  ],
+  [
+    'original' => '$has_index_value_scalar["foo"]["bar"] = NULL;',
+    'settings' => [
+      'has_index_value_scalar' => [
+        'foo' => [
+          'bar' => (object) [
+            'value' => FALSE,
+            'required' => TRUE,
+            'comment' => 'comment',
+          ],
+        ],
+      ],
+    ],
+    'expected' => '$has_index_value_scalar["foo"]["bar"] = false; // comment',
+  ],
+  [
+    'original' => '$has_index_value_scalar["foo"]["bar"] = "foo";',
+    'settings' => [
+      'has_index_value_scalar' => [
+        'foo' => [
+          'value' => (object) [
+            'value' => ['value' => 2],
+            'required' => TRUE,
+            'comment' => 'comment',
+          ],
+        ],
+      ],
+    ],
+    'expected' => <<<'EXPECTED'
+$has_index_value_scalar["foo"]["bar"] = "foo";
+$has_index_value_scalar['foo']['value'] = array (
+'value' => 2,
+); // comment
+EXPECTED
+  ],
+];

--- a/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc
@@ -55,3 +55,73 @@ function test_form() {
     '#weight' => 100,
   ];
 }
+
+/**
+ * Provides the necessary user permissions for entity operations.
+ *
+ * @param string $entity_type_id
+ *   The entity type.
+ * @param string $operation
+ *   The operation, one of 'view', 'create', 'update' or 'delete'.
+ *
+ * @return array
+ *   The set of user permission strings.
+ */
+function entity_permissions($entity_type_id, $operation) {
+  switch ($entity_type_id) {
+    case 'entity_test':
+      switch ($operation) {
+        case 'view':
+          return ['view test entity'];
+        case 'create':
+        case 'update':
+        case 'delete':
+          return ['administer entity_test content'];
+      }
+    case 'node':
+      switch ($operation) {
+        case 'view':
+          return ['access content'];
+        case 'create':
+          return ['create resttest content'];
+        case 'update':
+          return ['edit any resttest content'];
+        case 'delete':
+          return ['delete any resttest content'];
+      }
+
+    case 'comment':
+      switch ($operation) {
+        case 'view':
+          return ['access comments'];
+
+        case 'create':
+          return ['post comments', 'skip comment approval'];
+
+        case 'update':
+          return ['edit own comments'];
+
+        case 'delete':
+          return ['administer comments'];
+      }
+      break;
+
+    case 'user':
+      switch ($operation) {
+        case 'view':
+          return ['access user profiles'];
+
+        default:
+          return ['administer users'];
+      }
+
+    default:
+      if (isConfigEntity($entity_type_id)) {
+        $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
+        if ($admin_permission = $entity_type->getAdminPermission()) {
+          return [$admin_permission];
+        }
+      }
+  }
+  return [];
+}

--- a/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc
@@ -37,3 +37,21 @@ function example_field_formatter_view($entity_type, $entity, $field, $instance, 
   return $element;
 
 }
+
+/**
+ * A test function.
+ */
+function test_form() {
+  /*
+   * Here is some long form comment which is discouraged but not forbidden,
+   * I think? It goes over multiple lines in this pseudo doc comment style.
+   * And even more text now.
+   */
+  $form['submit_connection'] = [
+    '#prefix' => "<br style='clear:both'/>",
+    '#name' => 'enter_connection_settings',
+    '#type' => 'submit',
+    '#value' => t('Enter connection settings'),
+    '#weight' => 100,
+  ];
+}

--- a/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc.fixed
@@ -63,3 +63,73 @@ function test_form() {
     '#weight' => 100,
   ];
 }
+
+/**
+ * Provides the necessary user permissions for entity operations.
+ *
+ * @param string $entity_type_id
+ *   The entity type.
+ * @param string $operation
+ *   The operation, one of 'view', 'create', 'update' or 'delete'.
+ *
+ * @return array
+ *   The set of user permission strings.
+ */
+function entity_permissions($entity_type_id, $operation) {
+  switch ($entity_type_id) {
+    case 'entity_test':
+      switch ($operation) {
+        case 'view':
+          return ['view test entity'];
+        case 'create':
+        case 'update':
+        case 'delete':
+          return ['administer entity_test content'];
+      }
+    case 'node':
+      switch ($operation) {
+        case 'view':
+          return ['access content'];
+        case 'create':
+          return ['create resttest content'];
+        case 'update':
+          return ['edit any resttest content'];
+        case 'delete':
+          return ['delete any resttest content'];
+      }
+
+    case 'comment':
+      switch ($operation) {
+        case 'view':
+          return ['access comments'];
+
+        case 'create':
+          return ['post comments', 'skip comment approval'];
+
+        case 'update':
+          return ['edit own comments'];
+
+        case 'delete':
+          return ['administer comments'];
+      }
+      break;
+
+    case 'user':
+      switch ($operation) {
+        case 'view':
+          return ['access user profiles'];
+
+        default:
+          return ['administer users'];
+      }
+
+    default:
+      if (isConfigEntity($entity_type_id)) {
+        $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
+        if ($admin_permission = $entity_type->getAdminPermission()) {
+          return [$admin_permission];
+        }
+      }
+  }
+  return [];
+}

--- a/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc.fixed
@@ -137,3 +137,81 @@ function entity_permissions($entity_type_id, $operation) {
   }
   return [];
 }
+
+$tests = [
+  [
+    'original' => '$no_index_value_scalar = TRUE;',
+    'settings' => [
+      'no_index_value_scalar' => (object) [
+        'value' => FALSE,
+        'comment' => 'comment',
+      ],
+    ],
+    'expected' => '$no_index_value_scalar = false; // comment',
+  ],
+  [
+    'original' => '$no_index_value_scalar = TRUE;',
+    'settings' => [
+      'no_index_value_foo' => [
+        'foo' => [
+          'value' => (object) [
+            'value' => NULL,
+            'required' => TRUE,
+            'comment' => 'comment',
+          ],
+        ],
+      ],
+    ],
+    'expected' => <<<'EXPECTED'
+$no_index_value_scalar = TRUE;
+$no_index_value_foo['foo']['value'] = NULL; // comment
+EXPECTED
+  ],
+  [
+    'original' => '$no_index_value_array = array("old" => "value");',
+    'settings' => [
+      'no_index_value_array' => (object) [
+        'value' => FALSE,
+        'required' => TRUE,
+        'comment' => 'comment',
+      ],
+    ],
+    'expected' => '$no_index_value_array = array("old" => "value");
+$no_index_value_array = false; // comment',
+  ],
+  [
+    'original' => '$has_index_value_scalar["foo"]["bar"] = NULL;',
+    'settings' => [
+      'has_index_value_scalar' => [
+        'foo' => [
+          'bar' => (object) [
+            'value' => FALSE,
+            'required' => TRUE,
+            'comment' => 'comment',
+          ],
+        ],
+      ],
+    ],
+    'expected' => '$has_index_value_scalar["foo"]["bar"] = false; // comment',
+  ],
+  [
+    'original' => '$has_index_value_scalar["foo"]["bar"] = "foo";',
+    'settings' => [
+      'has_index_value_scalar' => [
+        'foo' => [
+          'value' => (object) [
+            'value' => ['value' => 2],
+            'required' => TRUE,
+            'comment' => 'comment',
+          ],
+        ],
+      ],
+    ],
+    'expected' => <<<'EXPECTED'
+$has_index_value_scalar["foo"]["bar"] = "foo";
+$has_index_value_scalar['foo']['value'] = array (
+'value' => 2,
+); // comment
+EXPECTED
+  ],
+];

--- a/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/WhiteSpace/ScopeIndentUnitTest.inc.fixed
@@ -45,3 +45,21 @@ function example_field_formatter_view($entity_type, $entity, $field, $instance, 
   return $element;
 
 }
+
+/**
+ * A test function.
+ */
+function test_form() {
+  /*
+   * Here is some long form comment which is discouraged but not forbidden,
+   * I think? It goes over multiple lines in this pseudo doc comment style.
+   * And even more text now.
+   */
+  $form['submit_connection'] = [
+    '#prefix' => "<br style='clear:both'/>",
+    '#name' => 'enter_connection_settings',
+    '#type' => 'submit',
+    '#value' => t('Enter connection settings'),
+    '#weight' => 100,
+  ];
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -152,9 +152,6 @@
     </rule>
 
     <!-- Not compliant yet, should be fixed in the future. -->
-    <rule ref="PSR2.Classes.PropertyDeclaration">
-        <exclude-pattern>coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php</exclude-pattern>
-    </rule>
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
         <exclude-pattern>coder_sniffer/DrupalPractice/Sniffs/CodeAnalysis/VariableAnalysisSniff.php</exclude-pattern>
     </rule>


### PR DESCRIPTION
While fixing coding standards I noticed that this sniff is outdated from upstream, so I synced it again.

I will run this on Drupal core to see if it flags something unusual there.