### PR TITLE
fix for FunctionCommentSniff: Support object type hint for php 7.2 and greater

### DIFF
--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Test module.
+ */
+
+/**
+ * @param \stdClass $arg
+ *   Something here.
+ */
+function module_handler_test_all2_hook(object $arg) {
+  return $arg;
+}

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc
@@ -8,7 +8,9 @@
 /**
  * @param \stdClass $arg
  *   Something here.
+ * @param object $blarg
+ *   Another thing.
  */
-function module_handler_test_all2_hook(object $arg) {
+function module_handler_test_all2_hook(object $arg, object $blarg) {
   return $arg;
 }

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc.fixed
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Test module.
+ */
+
+/**
+ * @param object $arg
+ *   Something here.
+ */
+function module_handler_test_all2_hook(object $arg) {
+  return $arg;
+}

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.3.inc.fixed
@@ -8,7 +8,9 @@
 /**
  * @param object $arg
  *   Something here.
+ * @param object $blarg
+ *   Another thing.
  */
-function module_handler_test_all2_hook(object $arg) {
+function module_handler_test_all2_hook(object $arg, object $blarg) {
   return $arg;
 }

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.php
@@ -82,12 +82,12 @@ class FunctionCommentUnitTest extends CoderSniffUnitTest
 
         case 'FunctionCommentUnitTest.3.inc':
             if (PHP_VERSION_ID < 70200) {
-              return [
-                  9 => 1,
-                  12 => 1,
-              ];
+                return [
+                    9  => 1,
+                    12 => 1,
+                ];
             } else {
-              return [9 => 1];
+                return [9 => 1];
             }//end if
         }//end switch
 

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.php
@@ -84,7 +84,7 @@ class FunctionCommentUnitTest extends CoderSniffUnitTest
             if (PHP_VERSION_ID < 70200) {
                 return [
                     9  => 1,
-                    12 => 1,
+                    14 => 1,
                 ];
             } else {
                 return [9 => 1];

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.php
@@ -79,6 +79,16 @@ class FunctionCommentUnitTest extends CoderSniffUnitTest
 
         case 'FunctionCommentUnitTest.2.inc':
             return [8 => 1];
+
+        case 'FunctionCommentUnitTest.3.inc':
+            if (PHP_VERSION_ID < 70200) {
+              return [
+                  9 => 1,
+                  12 => 1,
+              ];
+            } else {
+              return [9 => 1];
+            }//end if
         }//end switch
 
     }//end getErrorList()


### PR DESCRIPTION
See drupal.org #3059698

There is some related code already in squizlabs:

squizlabs/php_codesniffer/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
```
                if ($this->phpVersion >= 70200) {
                    if ($suggestedName === 'object') {
                        $suggestedTypeHint = 'object';
                    }
                }
```