### PR TITLE
Declare ignored files relative to the root of the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-vendor
-composer.lock
+/vendor/
+/composer.lock


### PR DESCRIPTION
We are currently declaring that we are ignoring the `vendor` and `composer.lock` files regardless of where they are located. We are actually only ignoring them in the root folder. By specifying the correct path this not only works better with git but also with other tools that read this file, such as IDE's and command line tools.