### PR TITLE
Issue #3057988 Shorter @deprecated and @trigger_error sniff names

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/DeprecatedSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DeprecatedSniff.php
@@ -99,7 +99,7 @@ class DeprecatedSniff implements Sniff
                     && preg_match('/^[a-z\d_]+:\d{1,2}\.x\-\d{1,2}\.\d{1,2}-[a-z]{1,5}\d{1,2}$/', $version) === 0
                 ) {
                     $error = "The %s '%s' does not match the lower-case machine-name standard: drupal:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n]";
-                    $phpcsFile->addWarning($error, $stackPtr, 'DeprecatedVersionFormat', [$name, $version]);
+                    $phpcsFile->addWarning($error, $stackPtr, 'VersionFormat', [$name, $version]);
                 }
             }
         }
@@ -108,7 +108,7 @@ class DeprecatedSniff implements Sniff
         $seeTag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($stackPtr + 1), $commentEnd, false, '@see');
         if ($seeTag === false) {
             $error = 'Each @deprecated tag must have a @see tag immediately following it.';
-            $phpcsFile->addError($error, $stackPtr, 'DeprecatedMissingSeeTag');
+            $phpcsFile->addError($error, $stackPtr, 'MissingSeeTag');
             return;
         }
 
@@ -122,10 +122,10 @@ class DeprecatedSniff implements Sniff
         // message to assist in fixing.
         if (isset($matches[4]) === true && empty($matches[4]) === false) {
             $error = "The @see url '%s' should not end with a period.";
-            $phpcsFile->addWarning($error, $seeTag, 'DeprecatedPeriodAfterSeeUrl', [$crLink]);
+            $phpcsFile->addWarning($error, $seeTag, 'PeriodAfterSeeUrl', [$crLink]);
         } else if (empty($matches) === true) {
             $error = "The @see url '%s' does not match the standard: http(s)://www.drupal.org/node/n or http(s)://www.drupal.org/project/aaa/issues/n";
-            $phpcsFile->addWarning($error, $seeTag, 'DeprecatedWrongSeeUrlFormat', [$crLink]);
+            $phpcsFile->addWarning($error, $seeTag, 'WrongSeeUrlFormat', [$crLink]);
         }
 
     }//end process()

--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTriggerErrorSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTriggerErrorSniff.php
@@ -129,13 +129,13 @@ class FunctionTriggerErrorSniff extends FunctionCall
             // to the first period followed by a space is matched, as there may
             // be more than one sentence in the extra-info part.
             preg_match('/(.+) is deprecated in (\S+) (and is removed from) (?U)(.+)\. (.*)\. See (\S+)$/', $messageText, $matches);
-            $sniff = 'TriggerErrorTextLayoutStrict';
+            $sniff = 'TextLayoutStrict';
             $error = "The trigger_error message '%s' does not match the strict standard format: %%thing%% is deprecated in %%deprecation-version%% and is removed from %%removal-version%%. %%extra-info%%. See %%cr-link%%";
         } else {
             // Allow %extra-info% to be empty as this is optional in the relaxed
             // version.
             preg_match('/(.+) is deprecated in (\S+) (?U)(.+) (\S+)\. (.*)See (\S+)$/', $messageText, $matches);
-            $sniff = 'TriggerErrorTextLayoutRelaxed';
+            $sniff = 'TextLayoutRelaxed';
             $error = "The trigger_error message '%s' does not match the relaxed standard format: %%thing%% is deprecated in %%deprecation-version%% any free text %%removal-version%%. %%extra-info%%. See %%cr-link%%";
         }
 
@@ -153,7 +153,7 @@ class FunctionTriggerErrorSniff extends FunctionCall
                     && preg_match('/^[a-z\d_]+:\d{1,2}\.x\-\d{1,2}\.\d{1,2}$/', $version) === 0
                 ) {
                     $error = "The %s '%s' does not match the lower-case machine-name standard: drupal:n.n.n or project:n.x-n.n";
-                    $phpcsFile->addWarning($error, $argument['start'], 'TriggerErrorVersion', [$name, $version]);
+                    $phpcsFile->addWarning($error, $argument['start'], 'VersionFormat', [$name, $version]);
                 }
             }
 
@@ -166,10 +166,10 @@ class FunctionTriggerErrorSniff extends FunctionCall
             // specific message to assist in fixing.
             if (isset($crMatches[4]) === true && empty($crMatches[4]) === false) {
                 $error = "The url '%s' should not end with a period.";
-                $phpcsFile->addWarning($error, $argument['start'], 'TriggerErrorPeriodAfterSeeUrl', [$crLink]);
+                $phpcsFile->addWarning($error, $argument['start'], 'PeriodAfterSeeUrl', [$crLink]);
             } else if (empty($crMatches) === true) {
                 $error = "The url '%s' does not match the standard: http(s)://www.drupal.org/node/n or http(s)://www.drupal.org/project/aaa/issues/n";
-                $phpcsFile->addWarning($error, $argument['start'], 'TriggerErrorSeeUrlFormat', [$crLink]);
+                $phpcsFile->addWarning($error, $argument['start'], 'WrongSeeUrlFormat', [$crLink]);
             }
         }//end if
 


### PR DESCRIPTION
Drupal issue https://www.drupal.org/project/coder/issues/3057988#comment-13370817

Synchronise sniff names and remove unnecessary text. No actual coding changes.