### PR TITLE
Add rule to prevent direct usage of $_GET, $_POST, $_REQUEST, $_FILES and $_COOKIE

### DIFF
--- a/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
@@ -74,10 +74,6 @@ class GetRequestDataSniff implements Sniff
             $usedVar      = $phpcsFile->getTokensAsString(($openBracket + 1), ($closeBracket - $openBracket - 1));
         }
 
-        $type  = 'SuperglobalAccessed';
-        $error = 'The %s super global must not be accessed directly; inject the request.stack service and use $stack->getCurrentRequest()->';
-        $data  = [$varName];
-
         $requestPropertyMap = [
             '$_REQUEST' => 'request',
             '$_GET'     => 'query',
@@ -85,10 +81,16 @@ class GetRequestDataSniff implements Sniff
             '$_FILES'   => 'files',
         ];
 
+        $type  = 'SuperglobalAccessed';
+        $error = 'The %s super global must not be accessed directly; inject the request.stack service and use $stack->getCurrentRequest()->%s';
+        $data  = [
+            $varName,
+            $requestPropertyMap[$varName],
+        ];
+
         if ($usedVar !== '') {
             $type  .= 'WithVar';
-            $error .= '%s->get(%s)';
-            $data[] = $requestPropertyMap[$varName];
+            $error .= '->get(%s)';
             $data[] = $usedVar;
         }
 

--- a/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
@@ -60,6 +60,7 @@ class GetRequestDataSniff implements Sniff
             && $varName !== '$_GET'
             && $varName !== '$_POST'
             && $varName !== '$_FILES'
+            && $varName !== '$_COOKIE'
         ) {
             return;
         }
@@ -79,6 +80,7 @@ class GetRequestDataSniff implements Sniff
             '$_GET'     => 'query',
             '$_POST'    => 'request',
             '$_FILES'   => 'files',
+            '$_COOKIE'  => 'cookies',
         ];
 
         $type  = 'SuperglobalAccessed';

--- a/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * \DrupalPractice\Sniffs\Variables\GetRequestDataSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace DrupalPractice\Sniffs\Variables;
+
+use DrupalPractice\Project;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Ensures that Symfony request object is used to access super globals.
+ *
+ * Checks the usage of @author tags.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class GetRequestDataSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [T_VARIABLE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void|int
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (Project::getCoreVersion($phpcsFile) < 8) {
+            // No need to check this file again, mark it as done.
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        $tokens  = $phpcsFile->getTokens();
+        $varName = $tokens[$stackPtr]['content'];
+        if ($varName !== '$_REQUEST'
+            && $varName !== '$_GET'
+            && $varName !== '$_POST'
+            && $varName !== '$_FILES'
+        ) {
+            return;
+        }
+
+        // If we get to here, the super global was used incorrectly.
+        // First find out how it is being used.
+        $usedVar = '';
+
+        $openBracket = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($tokens[$openBracket]['code'] === T_OPEN_SQUARE_BRACKET) {
+            $closeBracket = $tokens[$openBracket]['bracket_closer'];
+            $usedVar      = $phpcsFile->getTokensAsString(($openBracket + 1), ($closeBracket - $openBracket - 1));
+        }
+
+        $type  = 'SuperglobalAccessed';
+        $error = 'The %s super global must not be accessed directly; inject the request.stack service and use $stack->getCurrentRequest()->';
+        $data  = [$varName];
+
+        $requestPropertyMap = [
+            '$_REQUEST' => 'request',
+            '$_GET'     => 'query',
+            '$_POST'    => 'request',
+            '$_FILES'   => 'files',
+        ];
+
+        if ($usedVar !== '') {
+            $type  .= 'WithVar';
+            $error .= '%s->get(%s)';
+            $data[] = $requestPropertyMap[$varName];
+            $data[] = $usedVar;
+        }
+
+        $error .= ' instead';
+        $phpcsFile->addError($error, $stackPtr, $type, $data);
+
+    }//end process()
+
+
+}//end class

--- a/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.inc
+++ b/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+$get = $_GET['test_get'];
+$post = $_POST['test_post'];
+$request = $_REQUEST['test_request'];
+$files = $_FILES['test_files'];

--- a/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.inc
+++ b/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.inc
@@ -4,3 +4,8 @@ $get = $_GET['test_get'];
 $post = $_POST['test_post'];
 $request = $_REQUEST['test_request'];
 $files = $_FILES['test_files'];
+
+$get = $_GET;
+$post = $_POST;
+$request = $_REQUEST;
+$files = $_FILES;

--- a/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.inc
+++ b/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.inc
@@ -4,8 +4,10 @@ $get = $_GET['test_get'];
 $post = $_POST['test_post'];
 $request = $_REQUEST['test_request'];
 $files = $_FILES['test_files'];
+$cookie = $_COOKIE['test_cookie'];
 
 $get = $_GET;
 $post = $_POST;
 $request = $_REQUEST;
 $files = $_FILES;
+$cookie = $_COOKIE;

--- a/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.php
+++ b/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.php
@@ -23,10 +23,12 @@ class GetRequestDataUnitTest extends CoderSniffUnitTest
             4  => 1,
             5  => 1,
             6  => 1,
-            8  => 1,
+            7  => 1,
             9  => 1,
             10 => 1,
             11 => 1,
+            12 => 1,
+            13 => 1,
         ];
 
     }//end getErrorList()

--- a/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.php
+++ b/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.php
@@ -19,10 +19,14 @@ class GetRequestDataUnitTest extends CoderSniffUnitTest
     public function getErrorList()
     {
         return [
-            3 => 1,
-            4 => 1,
-            5 => 1,
-            6 => 1,
+            3  => 1,
+            4  => 1,
+            5  => 1,
+            6  => 1,
+            8  => 1,
+            9  => 1,
+            10 => 1,
+            11 => 1,
         ];
 
     }//end getErrorList()

--- a/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.php
+++ b/coder_sniffer/DrupalPractice/Test/Variables/GetRequestDataUnitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DrupalPractice\Sniffs\Variables;
+
+use Drupal\Test\CoderSniffUnitTest;
+
+class GetRequestDataUnitTest extends CoderSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getErrorList()
+    {
+        return [
+            3 => 1,
+            4 => 1,
+            5 => 1,
+            6 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class

--- a/coder_sniffer/DrupalPractice/Test/Variables/test.info.yml
+++ b/coder_sniffer/DrupalPractice/Test/Variables/test.info.yml
@@ -1,0 +1,3 @@
+name: Test
+type: module
+core: 8.x


### PR DESCRIPTION
Reference: https://www.drupal.org/project/coder/issues/2958175