### PR TITLE
Recognise 'yield from' as valid return statement

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -279,7 +279,7 @@ class FunctionCommentSniff implements Sniff
                             $searchStart        = $stackPtr;
                             $foundNonVoidReturn = false;
                             do {
-                                $returnToken = $phpcsFile->findNext([T_RETURN, T_YIELD], $searchStart, $endToken);
+                                $returnToken = $phpcsFile->findNext([T_RETURN, T_YIELD, T_YIELD_FROM], $searchStart, $endToken);
                                 if ($returnToken === false && $foundReturnToken === false) {
                                     $error = '@return doc comment specified, but function has no return statement';
                                     $phpcsFile->addError($error, $return, 'InvalidNoReturn');

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc
@@ -506,3 +506,15 @@ class Small {
 function test37(array $matches, array $sub_key, $to) {
 
 }
+
+/**
+ * Yield from should be a recognised return statement.
+ *
+ * @return int
+ *   Integer value.
+ */
+function test38($a, $b) {
+  for ($i = 1; $i <= 3; $i++) {
+    yield from $i;
+  }
+}

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc
@@ -510,11 +510,9 @@ function test37(array $matches, array $sub_key, $to) {
 /**
  * Yield from should be a recognised return statement.
  *
- * @return int
- *   Integer value.
+ * @return Generator
+ *   Generator value.
  */
 function test38($a, $b) {
-  for ($i = 1; $i <= 3; $i++) {
-    yield from $i;
-  }
+  yield from [$a, $b];
 }

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -532,3 +532,15 @@ class Small {
 function test37(array $matches, array $sub_key, $to) {
 
 }
+
+/**
+ * Yield from should be a recognised return statement.
+ *
+ * @return int
+ *   Integer value.
+ */
+function test38($a, $b) {
+  for ($i = 1; $i <= 3; $i++) {
+    yield from $i;
+  }
+}

--- a/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -536,11 +536,9 @@ function test37(array $matches, array $sub_key, $to) {
 /**
  * Yield from should be a recognised return statement.
  *
- * @return int
- *   Integer value.
+ * @return Generator
+ *   Generator value.
  */
 function test38($a, $b) {
-  for ($i = 1; $i <= 3; $i++) {
-    yield from $i;
-  }
+  yield from [$a, $b];
 }


### PR DESCRIPTION
Reference: https://www.drupal.org/project/coder/issues/3106904

Also checked if any other sniffs currently used the T_YIELD token, this was not the case.