### PR TITLE
chore(phpunit): Remove support for obsolete PHPUnit versions

### DIFF
--- a/coder_sniffer/Drupal/Test/phpunit-bootstrap.php
+++ b/coder_sniffer/Drupal/Test/phpunit-bootstrap.php
@@ -3,8 +3,3 @@
 require 'vendor/autoload.php';
 require 'CoderSniffUnitTest.php';
 require 'vendor/squizlabs/php_codesniffer/autoload.php';
-
-// Support older versions of PHPUnit on older PHP versions.
-if (class_exists('PHPUnit_Framework_TestCase') === true && class_exists('PHPUnit\Framework\TestCase') === false) {
-    class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
-}


### PR DESCRIPTION
Since we dropped old PHP versions this should not be necessary anymore.