### PR TITLE
Fix incorrect comment for CoderSniffUnitTest::checkAllSniffCodes()

### DIFF
--- a/coder_sniffer/Drupal/Test/CoderSniffUnitTest.php
+++ b/coder_sniffer/Drupal/Test/CoderSniffUnitTest.php
@@ -466,7 +466,7 @@ abstract class CoderSniffUnitTest extends TestCase
 
 
     /**
-     * False if just the current sniff should be checked, false if all sniffs should be checked.
+     * False if just the current sniff should be checked, true if all sniffs should be checked.
      *
      * @return bool
      */

--- a/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
+++ b/coder_sniffer/Drupal/Test/bad/BadUnitTest.php
@@ -460,7 +460,7 @@ class BadUnitTest extends CoderSniffUnitTest
 
 
     /**
-     * False if just the current sniff should be checked, false if all sniffs should be checked.
+     * False if just the current sniff should be checked, true if all sniffs should be checked.
      *
      * @return bool
      */

--- a/coder_sniffer/Drupal/Test/good/GoodUnitTest.php
+++ b/coder_sniffer/Drupal/Test/good/GoodUnitTest.php
@@ -76,7 +76,7 @@ class GoodUnitTest extends CoderSniffUnitTest
 
 
     /**
-     * False if just the current sniff should be checked, false if all sniffs should be checked.
+     * False if just the current sniff should be checked, true if all sniffs should be checked.
      *
      * @return bool
      */

--- a/coder_sniffer/DrupalPractice/Test/good/GoodUnitTest.php
+++ b/coder_sniffer/DrupalPractice/Test/good/GoodUnitTest.php
@@ -63,7 +63,7 @@ class GoodUnitTest extends CoderSniffUnitTest
 
 
     /**
-     * False if just the current sniff should be checked, false if all sniffs should be checked.
+     * False if just the current sniff should be checked, true if all sniffs should be checked.
      *
      * @return bool
      */


### PR DESCRIPTION
The CoderSniffUnitTest::checkAllSniffCodes() method currently states the following:
_False if just the current sniff should be checked, false if all sniffs should be checked._
This should be:
_False if just the current sniff should be checked, true if all sniffs should be checked._