### PR TITLE
Issue #3057988 by jonathan1055: Fixable deprecated @see url

### DIFF
--- a/coder_sniffer/Drupal/Test/Commenting/DeprecatedUnitTest.inc
+++ b/coder_sniffer/Drupal/Test/Commenting/DeprecatedUnitTest.inc
@@ -93,10 +93,10 @@ function w() {
  */
 
 /**
- * This block also has incorrect basic layout and is fixable.
+ * Incorrect text and the url has trailing punctuation. Both are fixable.
  *
  * @deprecated as of 8.8.3-dev, scheduled for removal in DRUPAL 9
  *   It has 'as of' not 'in', missing word 'drupal', has -dev in first version,
  *   has 'removal', upper-case 'drupal' and short second version.
- * @see http://www.drupal.org/node/123
+ * @see http://www.drupal.org/node/123?.
  */

--- a/coder_sniffer/Drupal/Test/Commenting/DeprecatedUnitTest.inc.fixed
+++ b/coder_sniffer/Drupal/Test/Commenting/DeprecatedUnitTest.inc.fixed
@@ -93,7 +93,7 @@ function w() {
  */
 
 /**
- * This block also has incorrect basic layout and is fixable.
+ * Incorrect text and the url has trailing punctuation. Both are fixable.
  *
  * @deprecated in drupal:8.8.3 and is removed from drupal:9.0.0.
  *   It has 'as of' not 'in', missing word 'drupal', has -dev in first version,

--- a/coder_sniffer/Drupal/Test/Commenting/DeprecatedUnitTest.php
+++ b/coder_sniffer/Drupal/Test/Commenting/DeprecatedUnitTest.php
@@ -27,15 +27,17 @@ class DeprecatedUnitTest extends CoderSniffUnitTest
     {
         return [
             // Basic layout is wrong. Missing see url.
-            24 => 2,
+            24  => 2,
             // No details given, check that the test gives two errors.
-            75 => 2,
+            75  => 2,
             // Layout OK but missing the extra info.
-            81 => 1,
+            81  => 1,
             // Text layout is wrong but fixable.
-            89 => 1,
+            89  => 1,
             // Text layout is wrong but fixable.
-            98 => 1,
+            98  => 1,
+            // See Url has trailing punctuation which is fixable.
+            101 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
d.o. issue https://www.drupal.org/project/coder/issues/3057988
I response to Klausi's request on PR #90 to remove the empty `if` block, I realised that the fixable url sniff is only done for functions. The @deprecated sniff also has to work for doc blocks (which it does) so the fixable @see url _is_ required. Added this, and a line in the unit test to check it.  The sniff caters not just for . but also ! ? and ; 