### PR TITLE
Make it possible to deprecate and point to semantic versions of contrib projects

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/DeprecatedSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DeprecatedSniff.php
@@ -169,14 +169,17 @@ class DeprecatedSniff implements Sniff
             }
         } else {
             // The text follows the basic layout. Now check that the versions
-            // match drupal:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n].
+            // match drupal:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n]
+            // or project:n.n.n or project:n.n.n-version[n].
             // The text must be all lower case and numbers can be one or two digits.
             foreach (['deprecation-version' => $matches[1], 'removal-version' => $matches[2]] as $name => $version) {
                 if (preg_match('/^drupal:\d{1,2}\.\d{1,2}\.\d{1,2}$/', $version) === 0
                     && preg_match('/^[a-z\d_]+:\d{1,2}\.x\-\d{1,2}\.\d{1,2}$/', $version) === 0
                     && preg_match('/^[a-z\d_]+:\d{1,2}\.x\-\d{1,2}\.\d{1,2}-[a-z]{1,5}\d{1,2}$/', $version) === 0
+                    && preg_match('/^[a-z\d_]+:\d{1,2}\.\d{1,2}\.\d{1,2}$/', $version) === 0
+                    && preg_match('/^[a-z\d_]+:\d{1,2}\.\d{1,2}\.\d{1,2}-[a-z]{1,5}\d{1,2}$/', $version) === 0
                 ) {
-                    $error = "The %s '%s' does not match the lower-case machine-name standard: drupal:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n]";
+                    $error = "The %s '%s' does not match the lower-case machine-name standard: drupal:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n] or project:n.n.n or project:n.n.n-version[n]";
                     $phpcsFile->addWarning($error, $stackPtr, 'DeprecatedVersionFormat', [$name, $version]);
                 }
             }

--- a/coder_sniffer/Drupal/Sniffs/Commenting/DeprecatedSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DeprecatedSniff.php
@@ -173,12 +173,7 @@ class DeprecatedSniff implements Sniff
             // or project:n.n.n or project:n.n.n-version[n].
             // The text must be all lower case and numbers can be one or two digits.
             foreach (['deprecation-version' => $matches[1], 'removal-version' => $matches[2]] as $name => $version) {
-                if (preg_match('/^drupal:\d{1,2}\.\d{1,2}\.\d{1,2}$/', $version) === 0
-                    && preg_match('/^[a-z\d_]+:\d{1,2}\.x\-\d{1,2}\.\d{1,2}$/', $version) === 0
-                    && preg_match('/^[a-z\d_]+:\d{1,2}\.x\-\d{1,2}\.\d{1,2}-[a-z]{1,5}\d{1,2}$/', $version) === 0
-                    && preg_match('/^[a-z\d_]+:\d{1,2}\.\d{1,2}\.\d{1,2}$/', $version) === 0
-                    && preg_match('/^[a-z\d_]+:\d{1,2}\.\d{1,2}\.\d{1,2}-[a-z]{1,5}\d{1,2}$/', $version) === 0
-                ) {
+                if (preg_match('/^[a-z\d_]+:(\d{1,2}\.\d{1,2}\.\d{1,2}|\d{1,2}\.x\-\d{1,2}\.\d{1,2})(-[a-z]{1,5}\d{1,2})?$/', $version) === 0) {
                     $error = "The %s '%s' does not match the lower-case machine-name standard: drupal:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n] or project:n.n.n or project:n.n.n-version[n]";
                     $phpcsFile->addWarning($error, $stackPtr, 'DeprecatedVersionFormat', [$name, $version]);
                 }

--- a/tests/Drupal/Commenting/DeprecatedUnitTest.inc
+++ b/tests/Drupal/Commenting/DeprecatedUnitTest.inc
@@ -100,3 +100,13 @@ function w() {
  *   has 'removal', upper-case 'drupal' and short second version.
  * @see http://www.drupal.org/node/123?.
  */
+
+/**
+ * This contrib doc block will pass the 'Deprecated' standards checks.
+ *
+ * @deprecated in project:8.1.0 and is removed from project:8.2.0. This uses
+ * semantic versioning, but this is now allowed, so we should allow it as well.
+ * @see http://www.drupal.org/node/7890
+ */
+function meanwhile() {
+}

--- a/tests/Drupal/Commenting/DeprecatedUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/DeprecatedUnitTest.inc.fixed
@@ -100,3 +100,13 @@ function w() {
  *   has 'removal', upper-case 'drupal' and short second version.
  * @see http://www.drupal.org/node/123
  */
+
+/**
+ * This contrib doc block will pass the 'Deprecated' standards checks.
+ *
+ * @deprecated in project:8.1.0 and is removed from project:8.2.0. This uses
+ * semantic versioning, but this is now allowed, so we should allow it as well.
+ * @see http://www.drupal.org/node/7890
+ */
+function meanwhile() {
+}


### PR DESCRIPTION
Now that we have semantic versioning, we should allow deprecation messages to point to these versions as well.

We might simplify the logic here now and remove the drupal:n.n.n altogether, but that would be part of the discussion here I guess? :)