### PR TITLE
tests(phpstan): Remove ignored false positives that have been fixed in PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.0.8",
         "ext-mbstring": "*",
-        "squizlabs/php_codesniffer": "^3.5.4",
+        "squizlabs/php_codesniffer": "^3.5.5",
         "symfony/yaml": ">=2.0.5"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -81,15 +81,5 @@ parameters:
             message: "#^Method Drupal\\\\Sniffs\\\\Files\\\\LineLengthSniff\\:\\:checkLineLength\\(\\) should return false\\|null but return statement is missing\\.$#"
             count: 1
             path: coder_sniffer/Drupal/Sniffs/Files/LineLengthSniff.php
-        # Upstream PHPCS problem where properties on Config are not set as
-        # class variables. Ignore.
-        -
-            message: "#^Access to an undefined property PHP_CodeSniffer\\\\Config\\:\\:\\$annotations\\.$#"
-            count: 1
-            path: coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
-        -
-            message: "#^Access to an undefined property PHP_CodeSniffer\\\\Config\\:\\:\\$.+\\.$#"
-            count: 5
-            path: coder_sniffer/Drupal/Test/CoderSniffUnitTest.php
         # We support PHP 7.0 which does not have the "void" return type hint.
         - '#^Method .+ has no return typehint specified\.$#'


### PR DESCRIPTION
This issue has been fixed upstream in PHPCS via commit https://github.com/squizlabs/PHP_CodeSniffer/commit/51d44091ba9ba3fa7bdf8046dcc1c6768d0cc774