### PR TITLE
fix(OptionsTSniff): Fix false positive '#options' property have to run through t()

### DIFF
--- a/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
@@ -84,15 +84,22 @@ class OptionsTSniff implements Sniff
         // We want to find if the element "#options" belongs to a form element.
         // Array with selectable options for a form element.
         $formElements = [
-          "'checkboxes'",
-          "'radios'",
-          "'select'",
-          "'tableselect'",
+            "'checkboxes'",
+            "'radios'",
+            "'select'",
+            "'tableselect'",
         ];
         // Find beggining of the array containing "#options" element.
-        $startArray = $phpcsFile->findPrevious(T_EQUAL, $stackPtr, null, false, "=");
+        $startArray = $phpcsFile->findPrevious(T_VARIABLE, $stackPtr);
+
         // Find next element on array of "#type".
-        $findType = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($startArray + 1), null, false, "'#type'");
+        $findType = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($startArray + 1), $statementEnd, false, "'#type'");
+
+        // Stop checking the array if its #type cannot be determined.
+        if ($findType === false) {
+            return;
+        }
+
         // Get the value of "#type".
         $valueType = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($findType + 1), null, false);
 

--- a/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
@@ -89,8 +89,8 @@ class OptionsTSniff implements Sniff
             "'select'",
             "'tableselect'",
         ];
-        // Find beggining of the array containing "#options" element.
-        $startArray = $phpcsFile->findPrevious(T_VARIABLE, $stackPtr);
+        // Find beginning of the array containing "#options" element.
+        $startArray = $phpcsFile->findStartOfStatement($stackPtr, [T_DOUBLE_ARROW, T_OPEN_SHORT_ARRAY, T_OPEN_PARENTHESIS, T_COMMA]);
 
         // Find next element on array of "#type".
         $findType = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($startArray + 1), $statementEnd, false, "'#type'");

--- a/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/General/OptionsTSniff.php
@@ -81,6 +81,21 @@ class OptionsTSniff implements Sniff
             $statementEnd = $tokens[$arrayToken]['bracket_closer'];
         }
 
+        // We want to find if the element "#options" belongs to a form element.
+        // Array with selectable options for a form element.
+        $formElements = [
+          "'checkboxes'",
+          "'radios'",
+          "'select'",
+          "'tableselect'",
+        ];
+        // Find beggining of the array containing "#options" element.
+        $startArray = $phpcsFile->findPrevious(T_EQUAL, $stackPtr, null, false, "=");
+        // Find next element on array of "#type".
+        $findType = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($startArray + 1), null, false, "'#type'");
+        // Get the value of "#type".
+        $valueType = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($findType + 1), null, false);
+
         // Go through the array by examining stuff after "=>".
         $arrow = $phpcsFile->findNext(T_DOUBLE_ARROW, ($arrayToken + 1), $statementEnd, false, null, true);
         while ($arrow !== false) {
@@ -95,7 +110,7 @@ class OptionsTSniff implements Sniff
             // and more than 3 characters long.
             if ($tokens[$arrayValue]['code'] === T_CONSTANT_ENCAPSED_STRING
                 && is_numeric(substr($tokens[$arrayValue]['content'], 1, -1)) === false
-                && strlen($tokens[$arrayValue]['content']) > 5
+                && strlen($tokens[$arrayValue]['content']) > 5 && in_array($tokens[$valueType]['content'], $formElements) === true
                 // Make sure that we don't check stuff in nested arrays within
                 // t() for example.
                 && $valueNestedParenthesis === $nestedParenthesis

--- a/tests/DrupalPractice/General/OptionsTUnitTest.inc
+++ b/tests/DrupalPractice/General/OptionsTUnitTest.inc
@@ -56,3 +56,17 @@ $form['display']['hide_thumbnail'] = [
     '0' => t('No', [], ['context' => 'test']),
   ],
 ];
+
+$form['link'] = [
+  '#type' => 'link',
+  '#title' => t('Download'),
+  '#url' => Url::fromUri('internal:/'),
+  '#options' => [
+    'attributes' => [
+      'target' => '_blank',
+      'class' => [
+        'home',
+      ],
+    ],
+  ],
+];

--- a/tests/DrupalPractice/General/OptionsTUnitTest.inc
+++ b/tests/DrupalPractice/General/OptionsTUnitTest.inc
@@ -48,6 +48,17 @@ $form['amount'] = [
   ],
 ];
 
+// Make sure this one does not trigger any warnings, as its type cannot be
+// easily determined.
+// This test array deliberately put in the middle of two arrays with '#type'
+// specified to ensure that lookup is bounded by the array itself and does not
+// leak to the beginning/end of the document.
+$form['ipsum']['#options'] = [
+  'attributes' => [
+    'target' => '_blank',
+  ],
+];
+
 $form['display']['hide_thumbnail'] = [
   '#title' => t('Hide Thumbnail', [], ['context' => 'test']),
   '#type' => 'radios',

--- a/tests/DrupalPractice/General/OptionsTUnitTest.inc
+++ b/tests/DrupalPractice/General/OptionsTUnitTest.inc
@@ -33,9 +33,11 @@ $form['display']['status'] = [
   ),
 ];
 
+$title_display = 'before';
 $form['amount'] = [
   '#type' => 'select',
   '#title' => t('Amount'),
+  '#title_display' => $title_display,
   '#options' => [
     '1' => '1',
     '2' => '2',
@@ -62,6 +64,7 @@ $form['ipsum']['#options'] = [
 $form['display']['hide_thumbnail'] = [
   '#title' => t('Hide Thumbnail', [], ['context' => 'test']),
   '#type' => 'radios',
+  '#required' => $required,
   '#options' => [
     '1' => t('Yes', [], ['context' => 'test']),
     '0' => t('No', [], ['context' => 'test']),

--- a/tests/DrupalPractice/General/OptionsTUnitTest.php
+++ b/tests/DrupalPractice/General/OptionsTUnitTest.php
@@ -46,7 +46,7 @@ class OptionsTUnitTest extends CoderSniffUnitTest
         return [
             14 => 1,
             31 => 1,
-            47 => 1,
+            49 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
fix(OptionsTSniff): Fix false positive '#options' property have to run through t() on non form element (#3062766 by zarabatana, Taran2L)