### PR TITLE
Use $parenthesisCloser column not the full line length

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Arrays/ArraySniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Arrays/ArraySniff.php
@@ -113,18 +113,13 @@ class ArraySniff implements Sniff
         if ($isInlineArray === true) {
             // Check if this array has more than one element and exceeds the
             // line length defined by $this->lineLimit.
-            $currentLine = $tokens[$stackPtr]['line'];
-            $tokenCount  = $stackPtr;
-            while ($tokenCount < ($phpcsFile->numTokens - 1) && $tokens[($tokenCount + 1)]['line'] === $currentLine) {
-                $tokenCount++;
-            };
-            $lineLength = ($tokens[$tokenCount]['column'] + $tokens[$tokenCount]['length'] - 1);
+            $arrayEnding = $tokens[$tokens[$stackPtr][$parenthesisCloser]]['column'];
 
-            if ($lineLength > $this->lineLimit) {
+            if ($arrayEnding > $this->lineLimit) {
                 $comma1 = $phpcsFile->findNext(T_COMMA, ($stackPtr + 1), $tokens[$stackPtr][$parenthesisCloser]);
                 if ($comma1 !== false) {
-                    $error = 'The array declaration line has %s characters (the limit is %s). The array content should be split up over multiple lines';
-                    $phpcsFile->addError($error, $stackPtr, 'LongLineDeclaration', [$lineLength, $this->lineLimit]);
+                    $error = 'The array declaration extends to column %s (the limit is %s). The array content should be split up over multiple lines';
+                    $phpcsFile->addError($error, $stackPtr, 'LongLineDeclaration', [$arrayEnding, $this->lineLimit]);
                 }
             }
 

--- a/tests/Drupal/Arrays/ArrayUnitTest.1.inc
+++ b/tests/Drupal/Arrays/ArrayUnitTest.1.inc
@@ -18,4 +18,8 @@ $array = array(
   'inline_two_elements_ok' => array('one-two-three', 'the-2nd-element-is-within-the-limit'),
   'inline_two_elements_ok2' => array('one-two-three-four', 'the-2nd-element-is-right-on-the-limit'),
   'inline_two_elements_not_ok' => array('one-two-three-four-five', 'the-2nd-element-extends-beyond-the-limit'),
+  'inline_two_elements_ok3' => func(['one-two-three-four', 'five'], 'other text which goes past the limit'),
+  'inline_two_elements_ok4' => func(['one-two-three-four', 'this-2nd-element-is-right-on-the-limit'], 'other text'),
+  'inline_two_elements_ok5' => func(['one-two-three-four'], ['second_array' => 'this-is-ok'], 'other text'),
+  'inline_two_elements_not_ok' => func(['one-two'], ['second_array' => 'three', 'four-five' => 'six'], 'other text'),
 );

--- a/tests/Drupal/Arrays/ArrayUnitTest.php
+++ b/tests/Drupal/Arrays/ArrayUnitTest.php
@@ -32,9 +32,9 @@ class ArrayUnitTest extends CoderSniffUnitTest
         case 'ArrayUnitTest.1.inc':
             return [
                 14 => 1,
-                15 => 1,
                 17 => 1,
                 20 => 1,
+                24 => 1,
             ];
         }
 


### PR DESCRIPTION
Durpal.org issue https://www.drupal.org/project/coder/issues/3169452

When calculating the lie length of inline array, use `$tokens[$tokens[$stackPtr][$parenthesisCloser]]['column']` not the full line length. Apologies to @klausi he did question this in my fix on [PR 114](https://github.com/pfrenssen/coder/pull/114)

This first commit fixes the code, but does not change the tests, and there will be one failure. This is where the array ends within the limit but the line extends beyond. I had marked this as a fault, but now it will not be. 