### PR TITLE
tests(Travis CI): Test PHP 7.4 on Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
     - php: 7.3
       dist: bionic
     - php: 7.4
-      dist: bionic
+      dist: focal
       env: PHPSTAN=1
 
 before_install:


### PR DESCRIPTION
We should test newer PHP versions on the latest Ubuntu.