### PR TITLE
Cater for variable interpolation strings in @trigger_error sniff

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTriggerErrorSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTriggerErrorSniff.php
@@ -86,7 +86,9 @@ class FunctionTriggerErrorSniff extends FunctionCall
             for ($i = $argument['start']; $i <= $argument['end']; $i++) {
                 if (in_array($tokens[$i]['code'], [T_WHITESPACE, T_STRING_CONCAT, T_COMMA]) === false) {
                     // For strings, remove the quotes using substr not trim.
-                    if ($tokens[$i]['code'] === T_CONSTANT_ENCAPSED_STRING) {
+                    // Simple strings are T_CONSTANT_ENCAPSED_STRING and strings
+                    // with variable interpolation are T_DOUBLE_QUOTED_STRING.
+                    if ($tokens[$i]['code'] === T_CONSTANT_ENCAPSED_STRING || $tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
                         $messageParts[] = substr($tokens[$i]['content'], 1, ($tokens[$i]['length'] - 2));
                     } else {
                         $messageParts[] = $tokens[$i]['content'];

--- a/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.1.inc
+++ b/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.1.inc
@@ -24,6 +24,8 @@
 @trigger_error(__METHOD__ . ' method is deprecated in drupal:8.4.0 and wont work in drupal:9.0.0. Use ' . __CLASS__ . '::bundle() instead. See https://www.drupal.org/project/drupal/issues/12345', E_USER_DEPRECATED);
 // Cater for concatenation with nothing else before 'is deprecated.
 @trigger_error(__NAMESPACE__ . ' is deprecated in drupal:8.5.0 and wont work in drupal:9.0.0. Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead. See https://www.drupal.org/node/2774931', E_USER_DEPRECATED);
+// Varibale interpolation, and no extra info (optional in relaxed standard).
+@trigger_error("Thing::\${$name} is deprecated in drupal:9.1.0 and will error in drupal:10.0.0. See https://www.drupal.org/node/3177488", E_USER_DEPRECATED);
 
 // ERRORS on general layout.
 // Wrong first part - missing word.

--- a/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.php
+++ b/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.php
@@ -23,12 +23,12 @@ class FunctionTriggerErrorUnitTest extends CoderSniffUnitTest
         switch ($testFile) {
         case 'FunctionTriggerErrorUnitTest.1.inc':
             return [
-                30 => 1,
                 32 => 1,
                 34 => 1,
                 36 => 1,
                 38 => 1,
                 40 => 1,
+                42 => 1,
             ];
         case 'FunctionTriggerErrorUnitTest.2.inc':
             return [29 => 1];
@@ -56,7 +56,6 @@ class FunctionTriggerErrorUnitTest extends CoderSniffUnitTest
         switch ($testFile) {
         case 'FunctionTriggerErrorUnitTest.1.inc':
             return [
-                42 => 1,
                 44 => 1,
                 46 => 1,
                 48 => 1,
@@ -69,6 +68,7 @@ class FunctionTriggerErrorUnitTest extends CoderSniffUnitTest
                 62 => 1,
                 64 => 1,
                 66 => 1,
+                68 => 1,
             ];
         case 'FunctionTriggerErrorUnitTest.2.inc':
         case 'FunctionTriggerErrorUnitTest.3.inc':


### PR DESCRIPTION
Drupal issue https://www.drupal.org/project/coder/issues/3178199

This first commit adds a new data row to the test file, to show that the current sniff incorrectly says that this fails the standard format.

Due to the new line being in the "passes" group of rows, the warning rows and error rows array all move down by 2 lines.