### PR TITLE
Add automated @todo fixing.

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/TodoCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/TodoCommentSniff.php
@@ -119,7 +119,7 @@ class TodoCommentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      * @param string                      $comment   The comment text.
-     * @param array                       $tokens    The token data.
+     * @param array<string>               $tokens    The token data.
      *
      * @return void
      */

--- a/coder_sniffer/Drupal/Sniffs/Commenting/TodoCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/TodoCommentSniff.php
@@ -83,7 +83,7 @@ class TodoCommentSniff implements Sniff
                 echo "Getting \$comment from \$tokens[$stackPtr]['content']\n";
             }
 
-            $this->checkTodoFormat($phpcsFile, $stackPtr, $comment);
+            $this->checkTodoFormat($phpcsFile, $stackPtr, $comment, $tokens);
         } else if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG) {
             // Document comment tag (i.e. comments that begin with "@").
             // Determine if this is related at all and build the full comment line
@@ -105,7 +105,7 @@ class TodoCommentSniff implements Sniff
                     echo "Result comment = $comment\n";
                 }
 
-                $this->checkTodoFormat($phpcsFile, $stackPtr, $comment);
+                $this->checkTodoFormat($phpcsFile, $stackPtr, $comment, $tokens);
             }//end if
         }//end if
 
@@ -119,37 +119,71 @@ class TodoCommentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      * @param string                      $comment   The comment text.
+     * @param array                       $tokens    The token data.
      *
      * @return void
      */
-    private function checkTodoFormat(File $phpcsFile, $stackPtr, string $comment)
+    private function checkTodoFormat(File $phpcsFile, int $stackPtr, string $comment, array $tokens)
     {
         if ($this->debug === true) {
             echo "Checking \$comment = '$comment'\n";
         }
 
-        $expression = '/(?x)   # Set free-space mode to allow this commenting
+        $expression = '/(?x)   # Set free-space mode to allow this commenting.
             ^(\/|\s)*          # At the start optionally match any forward slashes and spaces
-            (?i)               # set case-insensitive mode
-            (?=(               # start a positive non-consuming look-ahead to find all possible todos
-              @+to(-|\s|)+do   # if one or more @ allow spaces and - between the to and do
+            (?i)               # set case-insensitive mode.
+            (?=(               # Start a positive non-consuming look-ahead to find all possible todos
+              @+to(-|\s|)+do   # if one or more @ allow spaces and - between the to and do.
+              \h*(-|:)*        # Also match the trailing "-" or ":" so they can be replaced.
               |                # or
-              to(-)*do         # if no @ then only accept todo or to-do or to--do, etc, no spaces
+              to(-)*do         # If no @ then only accept todo or to-do or to--do, etc, no spaces.
+              (\s-|:)*         # Also match the trailing "-" or ":" so they can be replaced.
             ))
             (?-i)              # Reset to case-sensitive
             (?!                # Start another non-consuming look-ahead, this time negative
               @todo\s          # It has to match lower-case @todo followed by one space
-              (?!-|:)\S        # and then any non-space except - or :
+              (?!-|:)\S        # and then any non-space except "-" or ":".
             )/m';
 
-        if ((bool) preg_match($expression, $comment) === true) {
+        if ((bool) preg_match($expression, $comment, $matches) === true) {
             if ($this->debug === true) {
                 echo "Failed regex - give message\n";
             }
 
-            $comment = trim($comment, " /\r\n");
-            $phpcsFile->addWarning("'%s' should match the format '@todo Fix problem X here.'", $stackPtr, 'TodoFormat', [$comment]);
-        }
+            $commentTrimmed = trim($comment, " /\r\n");
+            if ($commentTrimmed === '@todo') {
+                // We can't fix a comment that doesn't have any text.
+                $phpcsFile->addWarning("'%s' should match the format '@todo Fix problem X here.'", $stackPtr, 'TodoFormat', [$commentTrimmed]);
+                $fix = false;
+            } else {
+                // Comments with description text are fixable.
+                $fix = $phpcsFile->addFixableWarning("'%s' should match the format '@todo Fix problem X here.'", $stackPtr, 'TodoFormat', [$commentTrimmed]);
+            }
+
+            if ($fix === true) {
+                if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG) {
+                    // Rewrite the comment past the token content to an empty
+                    // string as part of it may be part of the match, but not in
+                    // the token content. Then replace the token content with
+                    // the fixed comment from the matched content.
+                    $phpcsFile->fixer->beginChangeset();
+                    $index = ($stackPtr + 1);
+                    while ($tokens[$index]['line'] === $tokens[$stackPtr]['line']) {
+                        $phpcsFile->fixer->replaceToken($index, '');
+                        $index++;
+                    }
+
+                    $fixedTodo = str_replace($matches[2], '@todo ', $comment);
+                    $phpcsFile->fixer->replaceToken($stackPtr, $fixedTodo);
+                    $phpcsFile->fixer->endChangeset();
+                } else {
+                    // The full comment line text is available here, so the
+                    // replacement is fairly straightforward.
+                    $fixedTodo = str_replace($matches[2], '@todo ', $tokens[$stackPtr]['content']);
+                    $phpcsFile->fixer->replaceToken($stackPtr, $fixedTodo);
+                }//end if
+            }//end if
+        }//end if
 
     }//end checkTodoFormat()
 

--- a/coder_sniffer/Drupal/Sniffs/Commenting/TodoCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/TodoCommentSniff.php
@@ -119,7 +119,7 @@ class TodoCommentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      * @param string                      $comment   The comment text.
-     * @param array<string>               $tokens    The token data.
+     * @param array<array>                $tokens    The token data.
      *
      * @return void
      */

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.inc
@@ -23,6 +23,7 @@
  * @to  do Error
  * @todo- Error
  * @todo - Error
+ * @todo
  * @todoError
  * @todo   Error
  * todo Error
@@ -48,6 +49,7 @@ function foo() {
   // @ToDO Error
   // @todo: Error
   // @todo : Error
+  // @todo
   // @to-do Error
   // @TO-DO Error
   // @To-Do Error

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.inc
@@ -1,9 +1,11 @@
 <?php
 
 /**
+ * @file
  * Test file for the todo standard.
  *
  * These are valid examples.
+ *
  * @todo Valid.
  * @todo valid with lower-case first letter
  * @todo $can start with a $
@@ -32,16 +34,17 @@
  * to-do Error
  */
 
+/**
+ * Example function.
+ */
 function foo() {
   // These are valid examples.
   // @todo Valid.
   // @todo valid with lower-case first letter
   // @todo $can start with a $
   // @todo \also with backslash
-
   // This is not a todo tag. It is a general comment and we do not want
   // to do the standards checking here.
-
   // These are all incorrect.
   // @TODO Error
   // @ToDo Error

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.inc
@@ -26,6 +26,7 @@
  * @todo- Error
  * @todo - Error
  * @todo
+ * @to-do
  * @todoError
  * @todo   Error
  * todo Error
@@ -53,6 +54,7 @@ function foo() {
   // @todo: Error
   // @todo : Error
   // @todo
+  // @to-do
   // @to-do Error
   // @TO-DO Error
   // @To-Do Error

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.inc
@@ -11,7 +11,8 @@
  * @todo $can start with a $
  * @todo \also with backslash
  *
- * These are all incorrect.
+ * These are all incorrect but can be fixed automatically.
+ *
  * @TODO Error
  * @ToDo Error
  * @TODo Error
@@ -25,14 +26,18 @@
  * @to  do Error
  * @todo- Error
  * @todo - Error
- * @todo
- * @to-do
  * @todoError
  * @todo   Error
  * todo Error
  * TODO Error
  * ToDo Error
  * to-do Error
+ *
+ * These are all incorrect but cannot be fully fixed automatically.
+ *
+ * @todo
+ * @to-do
+ * @TODO
  */
 
 /**
@@ -46,15 +51,13 @@ function foo() {
   // @todo \also with backslash
   // This is not a todo tag. It is a general comment and we do not want
   // to do the standards checking here.
-  // These are all incorrect.
+  // These are all incorrect but can be fixed automatically.
   // @TODO Error
   // @ToDo Error
   // @TODo Error
   // @ToDO Error
   // @todo: Error
   // @todo : Error
-  // @todo
-  // @to-do
   // @to-do Error
   // @TO-DO Error
   // @To-Do Error
@@ -68,4 +71,8 @@ function foo() {
   // TODO Error
   // ToDo Error
   // to-do Error
+  // These are all incorrect but cannot be fully fixed automatically.
+  // @todo
+  // @to-do
+  // @TODO
 }

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.inc.fixed
@@ -26,6 +26,7 @@
  * @todo Error
  * @todo Error
  * @todo
+ * @todo
  * @todo Error
  * @todo Error
  * @todo Error
@@ -52,6 +53,7 @@ function foo() {
   // @todo Error
   // @todo Error
   // @todo Error
+  // @todo
   // @todo
   // @todo Error
   // @todo Error

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.inc.fixed
@@ -11,7 +11,8 @@
  * @todo $can start with a $
  * @todo \also with backslash
  *
- * These are all incorrect.
+ * These are all incorrect but can be fixed automatically.
+ *
  * @todo Error
  * @todo Error
  * @todo Error
@@ -25,14 +26,18 @@
  * @todo Error
  * @todo Error
  * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ *
+ * These are all incorrect but cannot be fully fixed automatically.
+ *
  * @todo
  * @todo
- * @todo Error
- * @todo Error
- * @todo Error
- * @todo Error
- * @todo Error
- * @todo Error
+ * @todo
  */
 
 /**
@@ -46,26 +51,28 @@ function foo() {
   // @todo \also with backslash
   // This is not a todo tag. It is a general comment and we do not want
   // to do the standards checking here.
-  // These are all incorrect.
+  // These are all incorrect but can be fixed automatically.
   // @todo Error
   // @todo Error
   // @todo Error
   // @todo Error
   // @todo Error
   // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // These are all incorrect but cannot be fully fixed automatically.
   // @todo
   // @todo
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
-  // @todo Error
+  // @todo
 }

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.inc.fixed
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @file
+ * Test file for the todo standard.
+ *
+ * These are valid examples.
+ *
+ * @todo Valid.
+ * @todo valid with lower-case first letter
+ * @todo $can start with a $
+ * @todo \also with backslash
+ *
+ * These are all incorrect.
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ * @todo Error
+ */
+
+/**
+ * Example function.
+ */
+function foo() {
+  // These are valid examples.
+  // @todo Valid.
+  // @todo valid with lower-case first letter
+  // @todo $can start with a $
+  // @todo \also with backslash
+  // This is not a todo tag. It is a general comment and we do not want
+  // to do the standards checking here.
+  // These are all incorrect.
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+  // @todo Error
+}

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.php
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.php
@@ -37,7 +37,7 @@ class TodoCommentUnitTest extends CoderSniffUnitTest
      */
     protected function getWarningList(string $testFile): array
     {
-        $warningList = (array_fill_keys(range(15, 35), 1) + array_fill_keys(range(50, 70), 1));
+        $warningList = (array_fill_keys(range(16, 34), 1) + array_fill_keys(range(38, 40), 1) + array_fill_keys(range(55, 73), 1) + array_fill_keys(range(75, 77), 1));
         return $warningList;
 
     }//end getWarningList()

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.php
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.php
@@ -37,7 +37,7 @@ class TodoCommentUnitTest extends CoderSniffUnitTest
      */
     protected function getWarningList(string $testFile): array
     {
-        $warningList = (array_fill_keys(range(13, 31), 1) + array_fill_keys(range(45, 63), 1));
+        $warningList = (array_fill_keys(range(13, 32), 1) + array_fill_keys(range(46, 65), 1));
         return $warningList;
 
     }//end getWarningList()

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.php
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.php
@@ -37,7 +37,7 @@ class TodoCommentUnitTest extends CoderSniffUnitTest
      */
     protected function getWarningList(string $testFile): array
     {
-        $warningList = (array_fill_keys(range(13, 32), 1) + array_fill_keys(range(46, 65), 1));
+        $warningList = (array_fill_keys(range(15, 34), 1) + array_fill_keys(range(49, 68), 1));
         return $warningList;
 
     }//end getWarningList()

--- a/tests/Drupal/Commenting/TodoCommentUnitTest.php
+++ b/tests/Drupal/Commenting/TodoCommentUnitTest.php
@@ -37,7 +37,7 @@ class TodoCommentUnitTest extends CoderSniffUnitTest
      */
     protected function getWarningList(string $testFile): array
     {
-        $warningList = (array_fill_keys(range(15, 34), 1) + array_fill_keys(range(49, 68), 1));
+        $warningList = (array_fill_keys(range(15, 35), 1) + array_fill_keys(range(50, 70), 1));
         return $warningList;
 
     }//end getWarningList()


### PR DESCRIPTION
Drupal.org issue: https://www.drupal.org/project/coder/issues/3177471

This replaces: https://github.com/pfrenssen/coder/pull/123.

---

> Running this on core returns the expected results with 1 exception. The fixer currently breaks when an empty @todo is given, for example:

```
function lorem() {
  // @todo
  $node = Node::load(1);
}
```
Results in the following

```
function lorem() {
  // @todo $node = Node::load(1);
}
```

> Could you add a test for the fixer? That way we can automatically validate the fixer. This can be achieved by adding the `TodoCommentUnitTest.inc` fixed file, containing the expected result of the autofix based on the `TodoCommentUnitTest.inc` file.


---

I fixed the new line creation and added a test for `@todo` statements by themselves. I added logic that marks them as unfixable since we can't know what the description should be.