### PR TITLE
tests(phpstan): Remove ignored rules that have been fixed in PHPStan and remove unused code

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -237,10 +237,6 @@ class FunctionCommentSniff implements Sniff
                     $typeNames      = explode('|', $type);
                     $suggestedNames = [];
                     $hasNull        = false;
-                    $hasMultiple    = false;
-                    if (count($typeNames) > 0) {
-                        $hasMultiple = true;
-                    }
 
                     foreach ($typeNames as $i => $typeName) {
                         if (strtolower($typeName) === 'null') {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0 || ^7.0",
-        "phpstan/phpstan": "^0.12.50"
+        "phpstan/phpstan": "^0.12.51"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -57,19 +57,3 @@ parameters:
             path: coder_sniffer/Drupal/Sniffs/Semantics/FunctionCall.php
         # False positive: Variable $a in isset() always exists and is not
         # nullable. https://github.com/phpstan/phpstan/issues/2816
-        -
-            count: 2
-            message: '~^Variable \$fileShort in isset\(\) always exists and is not nullable.$~'
-            path: coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
-        -
-            message: "#^Result of && is always false\\.$#"
-            count: 2
-            path: coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
-        -
-            message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-            count: 1
-            path: coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
-        -
-            message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
-            count: 1
-            path: coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php


### PR DESCRIPTION
This PR removes the following ignored rules and "fixes" an newly triggered error on FunctionCommentSniff:241, which was triggered on an unused if statement. These ignored rules have been fixed upstream in PHPStan 0.12.51