### PR TITLE
Doc tag group spacing

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
@@ -369,7 +369,6 @@ class DocCommentSniff implements Sniff
             '@param',
             '@return',
             '@throws',
-            '@ingroup',
         ];
         foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
             if ($pos > 0) {


### PR DESCRIPTION
D.O. issue https://www.drupal.org/project/coder/issues/3181485

The first commit only changes the sniff. As discussed in the d.o. issue, the logic check for `$currentTag` and `$previousTag` being the the list of 'group' tags to check should be `||` not `&&` because it should not matter what the other tag is. This then meant that inline tags also became in scope for testing (which is wrong) so the column is now checked to make sure we are only dealing with real doc tags.

The test will fail, which highlight the fact that `@ingroup` is in the list to be checked but is only semi-fixed.  