### PR TITLE
Improve fixer in ShortFullStop sniff

### DIFF
--- a/tests/Drupal/Commenting/DocCommentUnitTest.1.inc
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.1.inc
@@ -7,3 +7,36 @@
  * A comprehensive guide with examples is available at:
  * @link http://example.com Test link @endlink.
  */
+
+/**
+ * Short comment with acceptable ending punctuation that does not need fixing!
+ */
+
+/**
+ * It is an unlikely comment, but question marks are acceptable, and why not?
+ */
+
+/**
+ * Brackets are also an allowed ending with no warning()
+ */
+
+/**
+ * This is a short comment with no full stop that can be fixed automatically
+ */
+
+/**
+ * A comment ending in digits is fixable, but the number of these in Core is 0
+ */
+
+/**
+ * No full stop that should not be fixed, just give the error message;
+ */
+
+/**
+ * This is an error that should not be fixed either-
+ */
+
+/**
+ * This is the first doc comment but it spans on to a second line and adding a
+ * full-stop will not fix the short comment so just report the error
+ */

--- a/tests/Drupal/Commenting/DocCommentUnitTest.1.inc.fixed
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.1.inc.fixed
@@ -7,3 +7,36 @@
  * A comprehensive guide with examples is available at:
  * @link http://example.com Test link @endlink.
  */
+
+/**
+ * Short comment with acceptable ending punctuation that does not need fixing!
+ */
+
+/**
+ * It is an unlikely comment, but question marks are acceptable, and why not?
+ */
+
+/**
+ * Brackets are also an allowed ending with no warning()
+ */
+
+/**
+ * This is a short comment with no full stop that can be fixed automatically.
+ */
+
+/**
+ * A comment ending in digits is fixable, but the number of these in Core is 0.
+ */
+
+/**
+ * No full stop that should not be fixed, just give the error message;
+ */
+
+/**
+ * This is an error that should not be fixed either-
+ */
+
+/**
+ * This is the first doc comment but it spans on to a second line and adding a
+ * full-stop will not fix the short comment so just report the error
+ */

--- a/tests/Drupal/Commenting/DocCommentUnitTest.php
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.php
@@ -35,11 +35,20 @@ class DocCommentUnitTest extends CoderSniffUnitTest
                 101 => 1,
             ];
 
+        case 'DocCommentUnitTest.1.inc':
+            return [
+                24 => 1,
+                28 => 1,
+                32 => 1,
+                36 => 1,
+                41 => 2,
+            ];
+
         case 'DocCommentUnitTest.3.inc':
             return [4 => 1];
         default:
             return [];
-        }
+        }//end switch
 
     }//end getErrorList()
 


### PR DESCRIPTION
d.o. issue https://www.drupal.org/project/coder/issues/3184314
First change is to nly add full stop if short comment ends with alpah-numeric and is all contained on one line.