### PR TITLE
Add support for variadic function argument comment

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -698,9 +698,9 @@ class FunctionCommentSniff implements Sniff
             $suggestedType = implode('|', $suggestedNames);
 
             // Support variadic arguments.
-            if (preg_match('/(\s+)\.{3}$/', $param['type'], $matches)) {
-              $param['type_space'] = strlen($matches[1]);
-              $param['type'] = preg_replace('/\s+\.{3}$/', '', $param['type']);
+            if (preg_match('/(\s+)\.{3}$/', $param['type'], $matches) === 1) {
+                $param['type_space'] = strlen($matches[1]);
+                $param['type']       = preg_replace('/\s+\.{3}$/', '', $param['type']);
             }
 
             if (preg_match('/\s/', $param['type']) === 1) {

--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -696,6 +696,13 @@ class FunctionCommentSniff implements Sniff
             }
 
             $suggestedType = implode('|', $suggestedNames);
+
+            // Support variadic arguments.
+            if (preg_match('/(\s+)\.{3}$/', $param['type'], $matches)) {
+              $param['type_space'] = strlen($matches[1]);
+              $param['type'] = preg_replace('/\s+\.{3}$/', '', $param['type']);
+            }
+
             if (preg_match('/\s/', $param['type']) === 1) {
                 $error = 'Parameter type "%s" must not contain spaces';
                 $data  = [$param['type']];

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -1580,10 +1580,10 @@ function test23(): TestReturnType {
  * Variadic arguments with proper declaration.
  *
  * @param \Drupal\mymodule\Element ...$element
- *   The variadic paramater comment.
+ *   The variadic parameter comment.
  */
-function test_variadic(Element ...$element) {
-  // Nothing here.
+function test24(Element ...$element) {
+
 }
 
 /**

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -1577,6 +1577,16 @@ function test23(): TestReturnType {
 }
 
 /**
+ * Variadic arguments with proper declaration.
+ *
+ * @param \Drupal\mymodule\Element ...$element
+ *   The variadic paramater comment.
+ */
+function test_variadic(Element ...$element) {
+  // Nothing here.
+}
+
+/**
  * Test class.
  */
 class Test2 {


### PR DESCRIPTION
Variadic support is added to PHP 5.6. Drupal sniffs did not support the
proper syntax.

Added support for the proper syntax and added test.

See https://www.drupal.org/project/coder/issues/2878783

Fixes #136.