### PR TITLE
Use phpcs.xml, not phpcs.xml.dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Automatically fix coding standards
     phpcbf --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml /file/to/drupal/example_module
 
 
-## Store settings in a phpcs.xml.dist file
+## Store settings in a phpcs.xml file
 
 In order to save and commit your PHPCS settings to Git you can use a
-phpcs.xml.dist file in your project like this:
+phpcs.xml file in your project like this:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -108,7 +108,7 @@ phpcs.xml.dist file in your project like this:
 </ruleset>
 ```
 
-Then you can invoke phpcs without any options and it will read phpcs.xml.dist
+Then you can invoke phpcs without any options and it will read phpcs.xml
 from the current directory. This can also be useful for Continuous Integration
 setups.
 


### PR DESCRIPTION
Even though phpcs.xml.dist technically works - ref $defaultFiles in https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Config.php - it is contrary to normal usage. .dist files are normally not read and is used only for reference.

If we avoid using .dist files here, we are safe if PHP_CodeSniffer ever changes it's behavior and people using Coder will be less confused - like I was.