### PR TITLE
fix(VariableComment): Add support for union types

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
@@ -48,6 +48,9 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_STRING,
             T_NS_SEPARATOR,
             T_NULLABLE,
+            T_TYPE_UNION,
+            T_FALSE,
+            T_NULL,
         ];
 
         $commentEnd = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.0.8",
         "ext-mbstring": "*",
-        "squizlabs/php_codesniffer": "^3.5.6",
+        "squizlabs/php_codesniffer": "^3.6.0",
         "symfony/yaml": ">=2.0.5",
         "sirbrillig/phpcs-variable-analysis": "^2.10"
     },

--- a/tests/Drupal/Commenting/VariableCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/VariableCommentUnitTest.inc
@@ -51,4 +51,11 @@ class Test {
    */
   public ?Bar $bar;
 
+  /**
+   * Property fooBar.
+   *
+   * @var Foo|Bar|false|null
+   */
+  public Foo|Bar|FALSE|NULL $fooBar;
+
 }

--- a/tests/Drupal/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/VariableCommentUnitTest.inc.fixed
@@ -55,4 +55,11 @@ class Test {
    */
   public ?Bar $bar;
 
+  /**
+   * Property fooBar.
+   *
+   * @var Foo|Bar|false|null
+   */
+  public Foo|Bar|FALSE|NULL $fooBar;
+
 }


### PR DESCRIPTION
Reference: https://www.drupal.org/project/coder/issues/3249360

Upgraded PHP_CodeSniffer to 3.6.0 to add support for T_TYPE_UNION (https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.0)