### PR TITLE
@trigger_error deprecation sniff is too strict - allow the message to start with a variable

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTriggerErrorSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTriggerErrorSniff.php
@@ -69,6 +69,11 @@ class FunctionTriggerErrorSniff extends FunctionCall
         // Get the first argument passed to trigger_error().
         $argument = $this->getArgument(1);
 
+        // Skip variable deprecation messages.
+        if ($tokens[$argument['start']]['code'] === T_VARIABLE) {
+            return;
+        }
+
         // Extract the message text to check. If if it formed using sprintf()
         // then find the single overall string using ->findNext.
         if ($tokens[$argument['start']]['code'] === T_STRING

--- a/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.1.inc
+++ b/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.1.inc
@@ -24,8 +24,10 @@
 @trigger_error(__METHOD__ . ' method is deprecated in drupal:8.4.0 and wont work in drupal:9.0.0. Use ' . __CLASS__ . '::bundle() instead. See https://www.drupal.org/project/drupal/issues/12345', E_USER_DEPRECATED);
 // Cater for concatenation with nothing else before 'is deprecated.
 @trigger_error(__NAMESPACE__ . ' is deprecated in drupal:8.5.0 and wont work in drupal:9.0.0. Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead. See https://www.drupal.org/node/2774931', E_USER_DEPRECATED);
-// Varibale interpolation, and no extra info (optional in relaxed standard).
+// Variable interpolation, and no extra info (optional in relaxed standard).
 @trigger_error("Thing::\${$name} is deprecated in drupal:9.1.0 and will error in drupal:10.0.0. See https://www.drupal.org/node/3177488", E_USER_DEPRECATED);
+// Variable only.
+@trigger_error($message, E_USER_DEPRECATED);
 
 // ERRORS on general layout.
 // Wrong first part - missing word.

--- a/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.php
+++ b/tests/Drupal/Semantics/FunctionTriggerErrorUnitTest.php
@@ -23,12 +23,12 @@ class FunctionTriggerErrorUnitTest extends CoderSniffUnitTest
         switch ($testFile) {
         case 'FunctionTriggerErrorUnitTest.1.inc':
             return [
-                32 => 1,
                 34 => 1,
                 36 => 1,
                 38 => 1,
                 40 => 1,
                 42 => 1,
+                44 => 1,
             ];
         case 'FunctionTriggerErrorUnitTest.2.inc':
             return [29 => 1];
@@ -56,7 +56,6 @@ class FunctionTriggerErrorUnitTest extends CoderSniffUnitTest
         switch ($testFile) {
         case 'FunctionTriggerErrorUnitTest.1.inc':
             return [
-                44 => 1,
                 46 => 1,
                 48 => 1,
                 50 => 1,
@@ -69,6 +68,7 @@ class FunctionTriggerErrorUnitTest extends CoderSniffUnitTest
                 64 => 1,
                 66 => 1,
                 68 => 1,
+                70 => 1,
             ];
         case 'FunctionTriggerErrorUnitTest.2.inc':
         case 'FunctionTriggerErrorUnitTest.3.inc':


### PR DESCRIPTION
https://www.drupal.org/project/coder/issues/3226902