### PR TITLE
Corrected indentation in class declaration

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/ClassDeclarationSniff.php
@@ -27,6 +27,12 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
 
 
     /**
+     * {@inheritdoc}
+     */
+    public $indent = 2;
+
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array<int|string>


### PR DESCRIPTION
Reference: [Drupal.org issue](https://www.drupal.org/project/coder/issues/3300911).