### PR TITLE
fix(DocCommentLongArraySyntax): Fix infinite loop by ignoring malformed doc blocks

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentLongArraySyntaxSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentLongArraySyntaxSniff.php
@@ -55,7 +55,11 @@ class DocCommentLongArraySyntaxSniff implements Sniff
             $codeStart = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($codeEnd + 1), $commentEnd, false, '@code');
             if ($codeStart !== false) {
                 $codeEnd = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($codeStart + 1), $commentEnd, false, '@endcode');
-                if ($codeEnd !== false) {
+                // If the code block never ends then simply ignore this
+                // docblock, it is probably malformed.
+                if ($codeEnd === false) {
+                    break;
+                } else {
                     // Check for long array syntax use inside this @code annotation.
                     for ($i = ($codeStart + 1); $i < $codeEnd; $i++) {
                         if (preg_match('/\barray\s*\(/', $tokens[$i]['content']) === 1) {

--- a/tests/Drupal/Commenting/DocCommentLongArraySyntaxUnitTest.inc
+++ b/tests/Drupal/Commenting/DocCommentLongArraySyntaxUnitTest.inc
@@ -30,3 +30,29 @@ function test1() {
 function test2() {
 
 }
+
+/**
+ * Malformed code block that does not end correctly, ignore it.
+ *
+ * The structure of the array is:
+ * @code
+ * $workflow_array = [
+ *   'entity_state' => [
+ *     'user' => [
+ *       'transition1',
+ *       'transition2',
+ *     ],
+ *   ],
+ * ];
+ * @code
+ */
+function test3() {
+
+}
+
+/**
+ * The structure of the array @code ['a' => 'b'] @endcode
+ */
+function test4() {
+
+}


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3306999