### PR TITLE
stdclass is auto-corrected to object but it should not be 

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -37,8 +37,6 @@ class FunctionCommentSniff implements Sniff
         'Boolean'   => 'bool',
         'integer'   => 'int',
         'str'       => 'string',
-        'stdClass'  => 'object',
-        '\stdClass' => 'object',
         'number'    => 'int',
         'String'    => 'string',
         'type'      => 'mixed',


### PR DESCRIPTION
Original MR: https://git.drupalcode.org/project/coder/-/merge_requests/20
D.o issue: https://www.drupal.org/i/3313246