### PR TITLE
Avoid misleading message when inheritdoc is missing the curly braces

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
@@ -139,10 +139,23 @@ class DocCommentSniff implements Sniff
                 return;
             }
 
+            // If inheritDoc is found without curly braces it is identified as a T_DOC_COMMENT_TAG not a
+            // T_DOC_COMMENT_STRING. It would be misleading to give the 'Missing short description' error
+            // below, hence we give a more useful message and can fix it automatically.
+            if (stripos($tokens[$short]['content'], '@inheritdoc') === 0) {
+                $error = "{$tokens[$short]['content']} found. Did you mean {{$tokens[$short]['content']}}?";
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'InheritDocWithoutBraces');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($short, "{{$tokens[$short]['content']}}");
+                }
+
+                return;
+            }
+
             $error = 'Missing short description in doc comment';
             $phpcsFile->addError($error, $stackPtr, 'MissingShort');
             return;
-        }
+        }//end if
 
         if (isset($fileShort) === true) {
             $start = $fileShort;

--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
@@ -144,7 +144,7 @@ class DocCommentSniff implements Sniff
             // below, hence we give a more useful message and can fix it automatically.
             if (stripos($tokens[$short]['content'], '@inheritdoc') === 0) {
                 $error = "{$tokens[$short]['content']} found. Did you mean {{$tokens[$short]['content']}}?";
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'InheritDocWithoutBraces');
+                $fix   = $phpcsFile->addFixableError($error, $short, 'InheritDocWithoutBraces');
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken($short, "{{$tokens[$short]['content']}}");
                 }

--- a/tests/Drupal/Commenting/DocCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.inc
@@ -121,3 +121,18 @@ function test13() {
 function test14(array $matches, array $sub_key, $to) {
 
 }
+
+/**
+ * {@inheritdoc}
+ */
+function test15_this_inheritdoc_is_correct();
+
+/**
+ * @inheritdoc
+ */
+function test16_lower_case_fail_needs_braces();
+
+/**
+ * @inheritDoc
+ */
+function test17_camel_case_fail_needs_braces();

--- a/tests/Drupal/Commenting/DocCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.inc.fixed
@@ -137,11 +137,11 @@ function test14(array $matches, array $sub_key, $to) {
 function test15_this_inheritdoc_is_correct();
 
 /**
- * @inheritdoc
+ * {@inheritdoc}
  */
 function test16_lower_case_fail_needs_braces();
 
 /**
- * {@inheritdoc}
+ * {@inheritDoc}
  */
 function test17_camel_case_fail_needs_braces();

--- a/tests/Drupal/Commenting/DocCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.inc.fixed
@@ -130,3 +130,18 @@ function test13() {
 function test14(array $matches, array $sub_key, $to) {
 
 }
+
+/**
+ * {@inheritdoc}
+ */
+function test15_this_inheritdoc_is_correct();
+
+/**
+ * @inheritdoc
+ */
+function test16_lower_case_fail_needs_braces();
+
+/**
+ * {@inheritdoc}
+ */
+function test17_camel_case_fail_needs_braces();

--- a/tests/Drupal/Commenting/DocCommentUnitTest.php
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.php
@@ -33,6 +33,8 @@ class DocCommentUnitTest extends CoderSniffUnitTest
                 66  => 1,
                 100 => 4,
                 101 => 1,
+                130 => 1,
+                135 => 1,
             ];
 
         case 'DocCommentUnitTest.1.inc':

--- a/tests/Drupal/Commenting/DocCommentUnitTest.php
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.php
@@ -33,8 +33,8 @@ class DocCommentUnitTest extends CoderSniffUnitTest
                 66  => 1,
                 100 => 4,
                 101 => 1,
-                130 => 1,
-                135 => 1,
+                131 => 1,
+                136 => 1,
             ];
 
         case 'DocCommentUnitTest.1.inc':


### PR DESCRIPTION
d.o. issue https://www.drupal.org/project/coder/issues/2904801