### PR TITLE
Add camelCase inheritDoc example to test file

### DIFF
--- a/tests/Drupal/Commenting/DocCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.inc
@@ -125,7 +125,12 @@ function test14(array $matches, array $sub_key, $to) {
 /**
  * {@inheritdoc}
  */
-function test15_this_inheritdoc_is_correct();
+function test15_lower_case_inheritdoc();
+
+/**
+ * {@inheritDoc}
+ */
+function test15_camel_case_inheritdoc();
 
 /**
  * @inheritdoc

--- a/tests/Drupal/Commenting/DocCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.inc.fixed
@@ -134,7 +134,12 @@ function test14(array $matches, array $sub_key, $to) {
 /**
  * {@inheritdoc}
  */
-function test15_this_inheritdoc_is_correct();
+function test15_lower_case_inheritdoc();
+
+/**
+ * {@inheritDoc}
+ */
+function test15_camel_case_inheritdoc();
 
 /**
  * {@inheritdoc}

--- a/tests/Drupal/Commenting/DocCommentUnitTest.php
+++ b/tests/Drupal/Commenting/DocCommentUnitTest.php
@@ -33,8 +33,8 @@ class DocCommentUnitTest extends CoderSniffUnitTest
                 66  => 1,
                 100 => 4,
                 101 => 1,
-                131 => 1,
                 136 => 1,
+                141 => 1,
             ];
 
         case 'DocCommentUnitTest.1.inc':


### PR DESCRIPTION
This is a follow-up to #180 to simply add a camel case example of inheritDoc which does not currently need to be fixed and will pass. Having all four examples here together in the test file will make it easier to test a future sniff which may enforce either lowercase or camelcase. Do this now, before any more lines are added to the .inc and .inc.fixed files.