### PR TITLE
Add sniff to check and fix Use statement order

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
         phpstan: ['0']
         # We only need to run PHPStan once on the latest PHP version.
         include:

--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -121,6 +121,7 @@
  <rule ref="PSR2.Namespaces.UseDeclaration" />
 
  <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" />
+ <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
  <rule ref="SlevomatCodingStandard.PHP.ShortList" />
 
  <rule ref="Squiz.Arrays.ArrayDeclaration" />

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
         "sirbrillig/phpcs-variable-analysis": "^2.11.7",
         "slevomat/coding-standard": "^7.0 || ^8.0",
+        "cweagans/composer-patches": "*",
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/yaml": ">=3.4.0"
     },
@@ -30,9 +31,17 @@
     },
     "config": {
         "allow-plugins": {
+            "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "sort-packages": true
+    },
+    "extra": {
+        "patches": {
+            "slevomat/coding-standard": {
+                "Do not fix multi-part use stmt": "https://patch-diff.githubusercontent.com/raw/slevomat/coding-standard/pull/1551.diff"
+            }
+        }
     },
     "require-dev": {
         "phpstan/phpstan": "^1.7.12",

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,11 @@
     ],
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-mbstring": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
         "sirbrillig/phpcs-variable-analysis": "^2.11.7",
-        "slevomat/coding-standard": "^7.0 || ^8.0",
-        "cweagans/composer-patches": "*",
+        "slevomat/coding-standard": "^8.11",
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/yaml": ">=3.4.0"
     },
@@ -35,13 +34,6 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "sort-packages": true
-    },
-    "extra": {
-        "patches": {
-            "slevomat/coding-standard": {
-                "Do not fix multi-part use stmt": "https://patch-diff.githubusercontent.com/raw/slevomat/coding-standard/pull/1551.diff"
-            }
-        }
     },
     "require-dev": {
         "phpstan/phpstan": "^1.7.12",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     },
     "config": {
         "allow-plugins": {
-            "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "sort-packages": true

--- a/tests/Drupal/Classes/ClassCreateInstanceUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/ClassCreateInstanceUnitTest.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 
-use Vendor\DateTools\DateInterval;
 use Vendor\DateTools;
+use Vendor\DateTools\DateInterval;
 
 $x = array(new Foo(), array());
 $y = new Foo();

--- a/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.inc.fixed
@@ -5,12 +5,12 @@
  * Example.
  */
 
-use Test\MultiLineSecond;
-use Test\Foo;
-use Test\NotUsed;
-use Test\Bar;
 use Test\Alias as TestAlias;
+use Test\Bar;
+use Test\Foo;
 use Test\MultiLine as MultiLineAlias;
+use Test\MultiLineSecond;
+use Test\NotUsed;
 
 /**
  * Example.

--- a/tests/Drupal/Classes/UnusedUseStatementUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/UnusedUseStatementUnitTest.inc.fixed
@@ -2,12 +2,12 @@
 
 namespace MyNamespace\Depth;
 
-use Thing\NotUsed;
-use Thing\Fail\ActuallyUsed;
-use Test\TraitTest;
-use Thing\DifferentName as UsedOtherName;
 use Example\MyUrlHelper;
 use MyNamespace\Depth\SomeClass as CoreSomeClass;
+use Test\TraitTest;
+use Thing\DifferentName as UsedOtherName;
+use Thing\Fail\ActuallyUsed;
+use Thing\NotUsed;
 
 /**
  * Bla.

--- a/tests/Drupal/Classes/UseGlobalClassUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/UseGlobalClassUnitTest.inc.fixed
@@ -5,9 +5,9 @@
  * Example.
  */
 
+use Namespaced\MultiLine2 as MultiLineAlias2;
 use Namespaced\TestClass;
 use Namespaced\TestClassSecond as NamespacedAlias;
-use Namespaced\MultiLine2 as MultiLineAlias2;
 use function count;
 
 /**

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -20,9 +20,9 @@
 
 declare(strict_types=1);
 
-use Drupal\very_long_module_name_i_am_inventing_here_trololololo\SuperManager;
-use Drupal\some_module\ExampleClass as AliasedExampleClass;
 use Drupal\mymodule\TestReturnType;
+use Drupal\some_module\ExampleClass as AliasedExampleClass;
+use Drupal\very_long_module_name_i_am_inventing_here_trololololo\SuperManager;
 
 // Singleline comment before a code line.
 $foo = 'bar';


### PR DESCRIPTION
d.o. issue https://www.drupal.org/project/coder/issues/3310013
The first commit adds the new sniff whcih is the work of cburschka who provided a patch on the drupal issue.
The other commits, to fix the 'good' file and the four '.inc.fixed' files demonstrate that the new sniff works, has test coverage, and that the fixer works. 

Question - @klausi  do you want an extra specific test to show the sniff working? The fact that I had to change the good.php file and four .fixed files shows that it does work, and these checks will continue verify that the sniff continues to work and does not get broken by something else in future.