### PR TITLE
fix(ClassDeclaration): Fix indent to 2 spaces for multi-line class declaration

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/ClassDeclarationSniff.php
@@ -25,6 +25,13 @@ use PHP_CodeSniffer\Util\Tokens;
 class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
 {
 
+    /**
+     * {@inheritdoc}
+     *
+     * @var integer
+     */
+    public $indent = 2;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/tests/Drupal/Classes/ClassDeclarationUnitTest.inc
+++ b/tests/Drupal/Classes/ClassDeclarationUnitTest.inc
@@ -40,3 +40,14 @@ namespace {
 class ThirdClass {
   // No-op.
 }
+
+/**
+ * Class declaration over multiple lines.
+ */
+class WithManyInterfaces implements
+  Interface1,
+  Interface2,
+  Interface3,
+  Interface4 {
+
+}

--- a/tests/Drupal/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -40,3 +40,14 @@ namespace {
 class ThirdClass {
   // No-op.
 }
+
+/**
+ * Class declaration over multiple lines.
+ */
+class WithManyInterfaces implements
+  Interface1,
+  Interface2,
+  Interface3,
+  Interface4 {
+
+}


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3300911

continued from #172 