### PR TITLE
Array without key is allowed

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -147,6 +147,9 @@
  <rule ref="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast">
   <severity>0</severity>
  </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.NoKeySpecified">
+  <severity>0</severity>
+ </rule>
  <rule ref="Squiz.Arrays.ArrayDeclaration.NotLowerCase">
   <severity>0</severity>
  </rule>

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -162,6 +162,14 @@ $x = [
   ],
 ];
 
+// Array with a key followed by no key is allowed.
+// See https://www.drupal.org/project/coder/issues/3355778
+// and https://www.drupal.org/project/drupal/issues/2908266
+$form['testing_no_key'] = [
+  'a' => 'apple',
+  'banana',
+];
+
 // Arrays in function calls.
 foo(
   array(


### PR DESCRIPTION
Fixes https://www.drupal.org/project/coder/issues/3355778

Arrays which start with a key and then have elements without a key should be allowed. 

First add array without key to demonstrate the problem. Test should fail.