### PR TITLE
Replace squizlabs/php_codesniffer with phpcsstandards/php_codesniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Automated tests](https://github.com/pfrenssen/coder/workflows/Tests/badge.svg)](https://github.com/pfrenssen/coder/actions)
 
 Coder is a library for automated Drupal code reviews and coding standard fixes. It
-defines rules for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+defines rules for [PHP_CodeSniffer](https://github.com/phpcsstandards/PHP_CodeSniffer)
 
 Built-in support for:
 - "Drupal": Coding Standards https://www.drupal.org/coding-standards
@@ -162,4 +162,4 @@ Thank you!
 ## Credits
 
 Greg Sherwood and Squiz Pty Ltd, many sniffs are modified copies of their original
-work on [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer).
+work on [PHPCS](https://github.com/phpcsstandards/PHP_CodeSniffer).

--- a/coder_sniffer/Drupal/Sniffs/Commenting/ClassCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/ClassCommentSniff.php
@@ -21,7 +21,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/phpcsstandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */

--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * Largely copied from
  * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff to also
  * handle the "var" keyword. See
- * https://github.com/squizlabs/PHP_CodeSniffer/pull/1212
+ * https://github.com/phpcsstandards/PHP_CodeSniffer/pull/1212
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/coder_sniffer/Drupal/Sniffs/Files/FileEncodingSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Files/FileEncodingSniff.php
@@ -6,7 +6,7 @@
  * @package   PHP_CodeSniffer
  * @author    Klaus Purer <klaus.purer@mail.com>
  * @copyright 2016 Klaus Purer
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/phpcsstandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
@@ -24,7 +24,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  * @package   PHP_CodeSniffer
  * @author    Klaus Purer <klaus.purer@mail.com>
  * @copyright 2016 Klaus Purer
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/phpcsstandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */

--- a/coder_sniffer/Drupal/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -6,7 +6,7 @@
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/phpcsstandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
@@ -24,7 +24,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package   PHP_CodeSniffer
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/phpcsstandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 class UnnecessaryStringConcatSniff extends GenericUnnecessaryStringConcatSniff

--- a/coder_sniffer/Drupal/coder_unique_autoload_phpcs_bug_2751.php
+++ b/coder_sniffer/Drupal/coder_unique_autoload_phpcs_bug_2751.php
@@ -3,12 +3,12 @@
 /**
  * Includes classes which are not detected by PHP_CodeSniffer's autoloader.
  *
- * This file has a weird name on purpose because of https://github.com/squizlabs/PHP_CodeSniffer/pull/2751
+ * This file has a weird name on purpose because of https://github.com/phpcsstandards/PHP_CodeSniffer/pull/2751
  *
  * @category PHP
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
- * @see      https://github.com/squizlabs/PHP_CodeSniffer/issues/1469
+ * @see      https://github.com/phpcsstandards/PHP_CodeSniffer/issues/1469
  */
 
 // Abstract base classes are not discovered by the autoloader.

--- a/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
+++ b/coder_sniffer/DrupalPractice/Sniffs/Variables/GetRequestDataSniff.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  *
  * Inspired by GetRequestDataSniff.php from Squiz Labs.
  *
- * @see https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
+ * @see https://github.com/phpcsstandards/PHP_CodeSniffer/blob/master/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
  *
  * @category PHP
  * @package  PHP_CodeSniffer

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "php": ">=7.2",
         "ext-mbstring": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
+        "phpcsstandards/php_codesniffer": "^3.7.1",
         "sirbrillig/phpcs-variable-analysis": "^2.11.7",
         "slevomat/coding-standard": "^8.11",
-        "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/yaml": ">=3.4.0"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     bootstrapFiles:
         - tests/Drupal/phpunit-bootstrap.php
         # PHPStan does not find the constants in this file, so load it manually.
-        - vendor/squizlabs/php_codesniffer/src/Util/Tokens.php
+        - vendor/phpcsstandards/php_codesniffer/src/Util/Tokens.php
     ignoreErrors:
         # PHPStan does not support variable variables, see https://github.com/phpstan/phpstan/issues/2810
         -

--- a/tests/Drupal/CoderSniffUnitTest.php
+++ b/tests/Drupal/CoderSniffUnitTest.php
@@ -8,7 +8,7 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/phpcsstandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace Drupal\Test;

--- a/tests/Drupal/phpunit-bootstrap.php
+++ b/tests/Drupal/phpunit-bootstrap.php
@@ -2,4 +2,4 @@
 
 require 'vendor/autoload.php';
 require 'tests/Drupal/CoderSniffUnitTest.php';
-require 'vendor/squizlabs/php_codesniffer/autoload.php';
+require 'vendor/phpcsstandards/php_codesniffer/autoload.php';


### PR DESCRIPTION
Reference: https://www.drupal.org/project/coder/issues/3405657

This MR currently fails tests, as upstream repositories are waiting for the 3.8.0 release. 