### PR TITLE
fix(VariableComment): Support PHP attributes on class properties

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
@@ -74,9 +74,8 @@ class VariableCommentSniff extends AbstractVariableSniff
             break;
         }
 
-        if ($commentEnd === false
-            || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-            && $tokens[$commentEnd]['code'] !== T_COMMENT)
+        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
             $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
             return;

--- a/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
@@ -39,23 +39,41 @@ class VariableCommentSniff extends AbstractVariableSniff
     {
         $tokens = $phpcsFile->getTokens();
         $ignore = [
-            T_PUBLIC,
-            T_PRIVATE,
-            T_PROTECTED,
-            T_VAR,
-            T_STATIC,
-            T_WHITESPACE,
-            T_STRING,
-            T_NS_SEPARATOR,
-            T_NULLABLE,
-            T_READONLY,
-            T_TYPE_UNION,
-            T_TYPE_INTERSECTION,
-            T_FALSE,
-            T_NULL,
+            T_PUBLIC            => T_PUBLIC,
+            T_PRIVATE           => T_PRIVATE,
+            T_PROTECTED         => T_PROTECTED,
+            T_VAR               => T_VAR,
+            T_STATIC            => T_STATIC,
+            T_READONLY          => T_READONLY,
+            T_WHITESPACE        => T_WHITESPACE,
+            T_STRING            => T_STRING,
+            T_NS_SEPARATOR      => T_NS_SEPARATOR,
+            T_NAMESPACE         => T_NAMESPACE,
+            T_NULLABLE          => T_NULLABLE,
+            T_TYPE_UNION        => T_TYPE_UNION,
+            T_TYPE_INTERSECTION => T_TYPE_INTERSECTION,
+            T_NULL              => T_NULL,
+            T_TRUE              => T_TRUE,
+            T_FALSE             => T_FALSE,
+            T_SELF              => T_SELF,
+            T_PARENT            => T_PARENT,
         ];
 
-        $commentEnd = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
+        for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
+            if (isset($ignore[$tokens[$commentEnd]['code']]) === true) {
+                continue;
+            }
+
+            if ($tokens[$commentEnd]['code'] === T_ATTRIBUTE_END
+                && isset($tokens[$commentEnd]['attribute_opener']) === true
+            ) {
+                $commentEnd = $tokens[$commentEnd]['attribute_opener'];
+                continue;
+            }
+
+            break;
+        }
+
         if ($commentEnd === false
             || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
             && $tokens[$commentEnd]['code'] !== T_COMMENT)

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -1812,6 +1812,12 @@ interface Test5Interface {
 class TestPhpAttributes {
 
   /**
+   * Bar property.
+   */
+  #[NotBlank]
+  private bool $bar;
+
+  /**
    * Tests method with PHP attribute and docblock.
    */
   #[\ReturnTypeWillChange]


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3408524