### PR TITLE
chore(composer): Bump minimum version of PHPCS to 3.9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
         "sirbrillig/phpcs-variable-analysis": "^2.11.7",
         "slevomat/coding-standard": "^8.11",
-        "squizlabs/php_codesniffer": "^3.7.1",
+        "squizlabs/php_codesniffer": "^3.9.1",
         "symfony/yaml": ">=3.4.0"
     },
     "autoload": {


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3440603

To avoid support requests with outdated versions let's bump PHPCS to be sure.