### PR TITLE
#3483028 Remove use statement order rule

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -121,11 +121,6 @@
  <rule ref="PSR2.Namespaces.UseDeclaration" />
 
  <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" />
- <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
-  <properties>
-   <property name="caseSensitive" value="true"/>
-  </properties>
- </rule>
  <rule ref="SlevomatCodingStandard.PHP.ShortList" />
  <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
   <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing"/>

--- a/tests/Drupal/Classes/ClassCreateInstanceUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/ClassCreateInstanceUnitTest.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 
-use Vendor\DateTools;
 use Vendor\DateTools\DateInterval;
+use Vendor\DateTools;
 
 $x = array(new Foo(), array());
 $y = new Foo();

--- a/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.inc.fixed
@@ -5,12 +5,12 @@
  * Example.
  */
 
-use Test\Alias as TestAlias;
-use Test\Bar;
-use Test\Foo;
-use Test\MultiLine as MultiLineAlias;
 use Test\MultiLineSecond;
+use Test\Foo;
 use Test\NotUsed;
+use Test\Bar;
+use Test\Alias as TestAlias;
+use Test\MultiLine as MultiLineAlias;
 
 /**
  * Example.

--- a/tests/Drupal/Classes/UnusedUseStatementUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/UnusedUseStatementUnitTest.inc.fixed
@@ -2,12 +2,12 @@
 
 namespace MyNamespace\Depth;
 
-use Example\MyUrlHelper;
-use MyNamespace\Depth\SomeClass as CoreSomeClass;
+use Thing\NotUsed;
+use Thing\Fail\ActuallyUsed;
 use Test\TraitTest;
 use Thing\DifferentName as UsedOtherName;
-use Thing\Fail\ActuallyUsed;
-use Thing\NotUsed;
+use Example\MyUrlHelper;
+use MyNamespace\Depth\SomeClass as CoreSomeClass;
 
 /**
  * Bla.

--- a/tests/Drupal/Classes/UseGlobalClassUnitTest.inc.fixed
+++ b/tests/Drupal/Classes/UseGlobalClassUnitTest.inc.fixed
@@ -5,9 +5,9 @@
  * Example.
  */
 
-use Namespaced\MultiLine2 as MultiLineAlias2;
 use Namespaced\TestClass;
 use Namespaced\TestClassSecond as NamespacedAlias;
+use Namespaced\MultiLine2 as MultiLineAlias2;
 use function count;
 
 /**


### PR DESCRIPTION
#3483028 Remove use statement order rule
This PR removes the `SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses` sniff and adjusts the tests because the Use statements are no longer sorted when running the phpcbf fixer

Coder issue https://www.drupal.org/project/coder/issues/3483028