### PR TITLE
fix(VariableComment): Allow phpcs:ignore comments before member variables

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -80,6 +80,8 @@ jobs:
         if: ${{ matrix.extra-tests == '1' }}
         # In case Drupal core files have known problems that should be
         # ignored temporarily, add them with the --ignore option.
+        # @todo Remove ignore option once Coder 8.3.27 is released and Drupal
+        # core is updated to that version.
         run: |
           cd drupal/core
           ../../vendor/bin/phpcs -p -s --ignore=lib/Drupal/Core/Entity/EntityType.php,lib/Drupal/Core/Recipe/RecipeInputFormTrait.php,lib/Drupal/Core/Form/FormState.php,modules/migrate/src/Plugin/Migration.php,modules/views/src/ViewExecutable.php,modules/views/src/Plugin/views/style/StylePluginBase.php

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -82,4 +82,4 @@ jobs:
         # ignored temporarily, add them with the --ignore option.
         run: |
           cd drupal/core
-          ../../vendor/bin/phpcs -p
+          ../../vendor/bin/phpcs -p -s --ignore=lib/Drupal/Core/Entity/EntityType.php,lib/Drupal/Core/Recipe/RecipeInputFormTrait.php,lib/Drupal/Core/Form/FormState.php,modules/migrate/src/Plugin/Migration.php,modules/views/src/ViewExecutable.php,modules/views/src/Plugin/views/style/StylePluginBase.php

--- a/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
@@ -11,6 +11,7 @@ namespace Drupal\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Parses and verifies class property doc comments.
@@ -38,7 +39,7 @@ class VariableCommentSniff extends AbstractVariableSniff
     public function processMemberVar(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        $ignore = [
+        $ignore = ([
             T_PUBLIC            => T_PUBLIC,
             T_PRIVATE           => T_PRIVATE,
             T_PROTECTED         => T_PROTECTED,
@@ -57,7 +58,7 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_FALSE             => T_FALSE,
             T_SELF              => T_SELF,
             T_PARENT            => T_PARENT,
-        ];
+        ] + Tokens::$phpcsCommentTokens);
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
             if (isset($ignore[$tokens[$commentEnd]['code']]) === true) {

--- a/tests/Drupal/Commenting/VariableCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/VariableCommentUnitTest.inc
@@ -96,4 +96,10 @@ class Test {
    */
   protected UserStorageInterface&MockObject $userStorageMock2;
 
+  /**
+   * The search score.
+   */
+  // phpcs:ignore Drupal.NamingConventions.ValidVariableName.LowerCamelName
+  public string $search_score;
+
 }

--- a/tests/Drupal/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/VariableCommentUnitTest.inc.fixed
@@ -100,4 +100,10 @@ class Test {
    */
   protected UserStorageInterface&MockObject $userStorageMock2;
 
+  /**
+   * The search score.
+   */
+  // phpcs:ignore Drupal.NamingConventions.ValidVariableName.LowerCamelName
+  public string $search_score;
+
 }


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3477601