### PR TITLE
fix(VariableComment): Allow PHP 8.2 style type declarations with parentheses in @var comments

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -952,7 +952,7 @@ class FunctionCommentSniff implements Sniff
         // Also allow some more characters for special type hints supported by
         // PHPStan:
         // https://phpstan.org/writing-php-code/phpdoc-types#basic-types .
-        $type = preg_replace('/[^a-zA-Z0-9_\\\[\]\-<> ,"\{\}\?\':\*\|\&]/', '', $type);
+        $type = preg_replace('/[^a-zA-Z0-9_\\\[\]\-<> ,"\{\}\?\':\*\|\&\(\)]/', '', $type);
 
         return $type;
 

--- a/tests/Drupal/Commenting/VariableCommentUnitTest.inc
+++ b/tests/Drupal/Commenting/VariableCommentUnitTest.inc
@@ -102,4 +102,11 @@ class Test {
   // phpcs:ignore Drupal.NamingConventions.ValidVariableName.LowerCamelName
   public string $search_score;
 
+  /**
+   * Allow parentheses in the type declaration.
+   *
+   * @var (\Drupal\user\UserInterface&\PHPUnit\Framework\MockObject\MockObject)|null
+   */
+  protected $userMock;
+
 }

--- a/tests/Drupal/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/VariableCommentUnitTest.inc.fixed
@@ -106,4 +106,11 @@ class Test {
   // phpcs:ignore Drupal.NamingConventions.ValidVariableName.LowerCamelName
   public string $search_score;
 
+  /**
+   * Allow parentheses in the type declaration.
+   *
+   * @var (\Drupal\user\UserInterface&\PHPUnit\Framework\MockObject\MockObject)|null
+   */
+  protected $userMock;
+
 }


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3395015