### PR TITLE
feat(EmptyPHPStatement): Add sniff for empty PHP statements, same as Drupal core does

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -47,16 +47,18 @@
     <exclude-pattern>*.tpl.php</exclude-pattern>
   </rule>
 
+  <!-- Generic sniffs -->
+  <rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
   <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
   <rule ref="Generic.Files.ByteOrderMark"/>
+  <rule ref="Generic.Files.LineEndings"/>
   <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
   <rule ref="Generic.Formatting.SpaceAfterCast"/>
-
   <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+  <!-- Already covered by Drupal.WhiteSpace.Comma.NoSpace. -->
   <rule ref="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma">
     <severity>0</severity>
   </rule>
-
   <rule ref="Generic.NamingConventions.ConstructorName"/>
   <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
   <rule ref="Generic.PHP.DeprecatedFunctions"/>
@@ -64,13 +66,6 @@
   <rule ref="Generic.PHP.LowerCaseKeyword"/>
   <rule ref="Generic.PHP.UpperCaseConstant"/>
   <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
-
-  <!-- Use Unix newlines -->
-  <rule ref="Generic.Files.LineEndings">
-    <properties>
-      <property name="eolChar" value="\n"/>
-    </properties>
-  </rule>
 
   <rule ref="MySource.Debug.DebugCode"/>
   <rule ref="PEAR.Files.IncludingFile"/>

--- a/tests/Drupal/bad/BadUnitTest.php
+++ b/tests/Drupal/bad/BadUnitTest.php
@@ -434,6 +434,7 @@ class BadUnitTest extends CoderSniffUnitTest
                 809 => 1,
                 823 => 1,
                 824 => 1,
+                836 => 1,
             ];
         }//end switch
 

--- a/tests/Drupal/bad/bad.php.fixed
+++ b/tests/Drupal/bad/bad.php.fixed
@@ -884,7 +884,6 @@ function test28() {
 
 // Multiple statements on one line are not allowed.
 echo 'Hi!';
-;
 
 /**
  *


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3496958