### PR TITLE
fix(FullyQualifiedNamespace): Do not check names in PHP attributes for now

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Classes/FullyQualifiedNamespaceSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/FullyQualifiedNamespaceSniff.php
@@ -65,6 +65,11 @@ class FullyQualifiedNamespaceSniff implements Sniff
             return;
         }
 
+        // Skip names in PHP attributes, no standards defined yet.
+        if (isset($tokens[$stackPtr]['attribute_closer']) === true) {
+            return $tokens[$stackPtr]['attribute_closer'];
+        }
+
         // Check if this is a use statement and ignore those.
         $before = $phpcsFile->findPrevious([T_STRING, T_NS_SEPARATOR, T_WHITESPACE, T_COMMA, T_AS], $stackPtr, null, true);
         if ($tokens[$before]['code'] === T_USE || $tokens[$before]['code'] === T_NAMESPACE) {

--- a/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.4.inc
+++ b/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.4.inc
@@ -8,7 +8,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 
 /**
- * Test action which is always usable.
+ * Fully qualified names are allowed, there is no standard yet.
  */
 #[\Drupal\action_link\Attribute\StateAction(
   id: 'test_always',

--- a/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.4.inc.fixed
+++ b/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.4.inc.fixed
@@ -2,17 +2,18 @@
 
 namespace Drupal\action_link_test_plugins\Plugin\StateAction;
 
-use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\action_link\Attribute\StateAction;
+use Drupal\action_link\Entity\ActionLinkInterface;
 use Drupal\action_link\Plugin\StateAction\StateActionBase;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
 
 /**
- * Test action which is always usable.
+ * Fully qualified names are allowed, there is no standard yet.
  */
-#[StateAction(
+#[\Drupal\action_link\Attribute\StateAction(
   id: 'test_always',
-  label: new TranslatableMarkup('Test Always'),
-  description: new TranslatableMarkup('Test Always'),
+  label: new \Drupal\Core\StringTranslation\TranslatableMarkup('Test Always'),
+  description: new \Drupal\Core\StringTranslation\TranslatableMarkup('Test Always'),
   directions: [
     'change' => 'change',
   ]

--- a/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.php
+++ b/tests/Drupal/Classes/FullyQualifiedNamespaceUnitTest.php
@@ -38,11 +38,7 @@ class FullyQualifiedNamespaceUnitTest extends CoderSniffUnitTest
         case 'FullyQualifiedNamespaceUnitTest.3.inc':
             return [10 => 2];
         case 'FullyQualifiedNamespaceUnitTest.4.inc':
-            return [
-                13 => 1,
-                15 => 1,
-                16 => 1,
-            ];
+            return [];
         }//end switch
 
         return [];

--- a/tests/Drupal/Commenting/ClassCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/ClassCommentUnitTest.inc.fixed
@@ -5,8 +5,6 @@
  * Testing class/trait comments.
  */
 
-use Some\Attribute;
-
 /**
  *
  */
@@ -62,7 +60,7 @@ class WrongSpacing {
 /**
  * This is correct.
  */
-#[Attribute(foo: 'bar')]
+#[Some\Attribute(foo: 'bar')]
 #[Other\Attribute(baz: 'qux')]
 class DoubleAttribute {
 

--- a/tests/Drupal/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/tests/Drupal/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -5,8 +5,6 @@
  * Some function comment tests.
  */
 
-use Some\Attribute;
-
 /**
  * Test.
  *
@@ -581,7 +579,7 @@ class Test41 {
   /**
    * Method docblock.
    */
-  #[Attribute(foo: 'bar')]
+  #[Some\Attribute(foo: 'bar')]
   #[Other\Attribute(baz: 'qux')]
   public function method() {
   }

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -1929,6 +1929,12 @@ enum PUROSELY_WRONG_BUT_OK: int {
 class TestAlways extends StateActionBase {
 
   /**
+   * Partial names are ok in attributes for now.
+   */
+  #[Assert\NotBlank]
+  private bool $bar;
+
+  /**
    * Partially qualified names are ok in attributes for now.
    */
   #[CLI\Command(

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -1914,3 +1914,29 @@ enum PUROSELY_WRONG_BUT_OK: int {
   case One = 1;
   case Two = 2;
 }
+
+/**
+ * Fully qualified class name is allowed in PHP attributes for now.
+ */
+#[\Drupal\action_link\Attribute\StateAction(
+  id: 'test_always',
+  label: new \Drupal\Core\StringTranslation\TranslatableMarkup('Test Always'),
+  description: new \Drupal\Core\StringTranslation\TranslatableMarkup('Test Always'),
+  directions: [
+    'change' => 'change',
+  ]
+)]
+class TestAlways extends StateActionBase {
+
+  /**
+   * Partially qualified names are ok in attributes for now.
+   */
+  #[CLI\Command(
+    name: 'example',
+    aliases: ['example-foo']
+  )]
+  #[CLI\Option(name: 'pretty_format', description: 'Display the count in pretty format.')]
+  public function test(array $options = ['pretty-format' => TRUE]): void {
+  }
+
+}


### PR DESCRIPTION
Issues:
https://www.drupal.org/project/coder/issues/3408527
https://www.drupal.org/project/coder/issues/3483583