### PR TITLE
fix(phpcs): Update to 3.12 to detect spaces after final and abstract keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
         "sirbrillig/phpcs-variable-analysis": "^2.11.7",
         "slevomat/coding-standard": "^8.11",
-        "squizlabs/php_codesniffer": "^3.11.3",
+        "squizlabs/php_codesniffer": "^3.12.0",
         "symfony/yaml": ">=3.4.0"
     },
     "autoload": {

--- a/tests/Drupal/bad/BadUnitTest.php
+++ b/tests/Drupal/bad/BadUnitTest.php
@@ -61,6 +61,7 @@ class BadUnitTest extends CoderSniffUnitTest
         case 'bad.install':
             return [
                 1  => 1,
+                10 => 1,
                 13 => 1,
                 16 => 1,
                 51 => 1,


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3468410