### PR TITLE
fix(DocComment): Allow phpcs ignore comments before a tag (#3523506)

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
@@ -370,6 +370,7 @@ class DocCommentSniff implements Sniff
         if ($tokens[$firstTag]['line'] !== ($tokens[$prev]['line'] + 2)
             && isset($fileShort) === false
             && in_array($tokens[$firstTag]['content'], ['@code', '@link', '@endlink']) === false
+            && isset(Tokens::$phpcsCommentTokens[$tokens[$prev]['code']]) === false
         ) {
             $error = 'There must be exactly one blank line before the tags in a doc comment';
             $fix   = $phpcsFile->addFixableError($error, $firstTag, 'SpacingBeforeTags');

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -1986,3 +1986,27 @@ class TestPlugin {
   }
 
 }
+
+/**
+ * Provides a collection of condition plugins.
+ */
+class ConditionPluginCollection extends DefaultLazyPluginCollection {
+
+  /**
+   * An array of collected contexts for conditions.
+   *
+   * @var \Drupal\Component\Plugin\Context\ContextInterface[]
+   */
+  protected $conditionContexts = [];
+
+  /**
+   * {@inheritdoc}
+   *
+   * phpcs:ignore Drupal.Commenting.FunctionComment.MissingReturnComment
+   * @return \Drupal\Core\Condition\ConditionInterface
+   */
+  public function &get($instance_id) {
+    return 'x';
+  }
+
+}

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -1993,13 +1993,6 @@ class TestPlugin {
 class ConditionPluginCollection extends DefaultLazyPluginCollection {
 
   /**
-   * An array of collected contexts for conditions.
-   *
-   * @var \Drupal\Component\Plugin\Context\ContextInterface[]
-   */
-  protected $conditionContexts = [];
-
-  /**
    * {@inheritdoc}
    *
    * phpcs:ignore Drupal.Commenting.FunctionComment.MissingReturnComment


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3523506