### PR TITLE
fix(DocComment): Allow phpcs:ignore directives between param comments (#3526455)

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
@@ -406,6 +406,10 @@ class DocCommentSniff implements Sniff
                     continue;
                 }
 
+                // Search for the previous comment string but also allow for
+                // PHPCS ignore comments. If we encounter ignore comments then
+                // we need to be more lenient later by checking if $prev is an
+                // ignore comment.
                 $prev = $phpcsFile->findPrevious(
                     ([T_DOC_COMMENT_STRING => T_DOC_COMMENT_STRING] + Tokens::$phpcsCommentTokens),
                     ($tag - 1),

--- a/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/DocCommentSniff.php
@@ -407,7 +407,7 @@ class DocCommentSniff implements Sniff
                 }
 
                 $prev = $phpcsFile->findPrevious(
-                    T_DOC_COMMENT_STRING,
+                    ([T_DOC_COMMENT_STRING => T_DOC_COMMENT_STRING] + Tokens::$phpcsCommentTokens),
                     ($tag - 1),
                     $tokens[$commentStart]['comment_tags'][($pos - 1)]
                 );
@@ -442,6 +442,7 @@ class DocCommentSniff implements Sniff
             } else if ($isNewGroup === false
                 && (in_array($currentTag, $checkTags) === true || in_array($previousTag, $checkTags) === true)
                 && $previousTag !== $currentTag
+                && in_array($tokens[$prev]['code'], Tokens::$phpcsCommentTokens) === false
             ) {
                 $error = 'Separate the %s and %s sections by a blank line.';
                 $fix   = $phpcsFile->addFixableError($error, $tag, 'TagGroupSpacing', [$previousTag, $currentTag]);

--- a/tests/Drupal/good/good.php
+++ b/tests/Drupal/good/good.php
@@ -2020,3 +2020,30 @@ public function ignore_phpstan_comment() {
 // @phpstan-ignore-next-line missingType.return
 public function ignore_phpstan_comment_with_attribute_before() {
 }
+
+/**
+ * Test PHPCS ignore comments between param docs.
+ */
+interface BreadcrumbBuilderInterface {
+
+  /**
+   * Whether this breadcrumb builder should be used to build the breadcrumb.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * phpcs:ignore Drupal.Commenting.FunctionComment.ParamNameNoMatch
+   * @param \Drupal\Core\Cache\CacheableMetadata $cacheable_metadata
+   *   The cacheable metadata to add to if your check varies by or depends
+   *   on something. Anything you specify here does not have to be repeated in
+   *   the build() method as it will be merged in automatically.
+   *
+   * @return bool
+   *   TRUE if this builder should be used or FALSE to let other builders
+   *   decide.
+   *
+   * @todo Uncomment new method parameters before drupal:12.0.0, see
+   *   https://www.drupal.org/project/drupal/issues/3459277.
+   */
+  public function applies(RouteMatchInterface $route_match /* , CacheableMetadata $cacheable_metadata */);
+
+}


### PR DESCRIPTION
Issue: https://www.drupal.org/project/coder/issues/3526455