### PR TITLE
Exclude DisallowShortOpenTag from .yml files

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -65,7 +65,7 @@
   <rule ref="Generic.PHP.DeprecatedFunctions"/>
   <rule ref="Generic.PHP.DisallowShortOpenTag">
     <!-- Do not run this sniff on .yml files -->
-    <!-- <exclude-pattern>*.yml</exclude-pattern> -->
+    <exclude-pattern>*.yml</exclude-pattern>
   </rule>
   <rule ref="Generic.PHP.LowerCaseKeyword"/>
   <rule ref="Generic.PHP.UpperCaseConstant"/>

--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -2,6 +2,8 @@
 <!-- See http://pear.php.net/manual/en/package.php.php-codesniffer.annotated-ruleset.php -->
 <ruleset name="Drupal">
   <description>Drupal coding standard</description>
+  <!-- Files with these extensions are checked, see core/phpcs.xml.dist -->
+  <arg name="extensions" value="engine,inc,install,module,php,profile,test,theme,yml"/>
   <!-- All Drupal code files must be UTF-8 encoded and we treat them as such. -->
   <arg name="encoding" value="utf-8"/>
 
@@ -65,7 +67,7 @@
   <rule ref="Generic.PHP.DeprecatedFunctions"/>
   <rule ref="Generic.PHP.DisallowShortOpenTag">
     <!-- Do not run this sniff on .yml files -->
-    <exclude-pattern>**/*.yml</exclude-pattern>
+    <!-- <exclude-pattern>*.yml</exclude-pattern> -->
   </rule>
   <rule ref="Generic.PHP.LowerCaseKeyword"/>
   <rule ref="Generic.PHP.UpperCaseConstant"/>

--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -2,8 +2,6 @@
 <!-- See http://pear.php.net/manual/en/package.php.php-codesniffer.annotated-ruleset.php -->
 <ruleset name="Drupal">
   <description>Drupal coding standard</description>
-  <!-- Files with these extensions are checked, see core/phpcs.xml.dist -->
-  <arg name="extensions" value="engine,inc,install,module,php,profile,test,theme,yml"/>
   <!-- All Drupal code files must be UTF-8 encoded and we treat them as such. -->
   <arg name="encoding" value="utf-8"/>
 
@@ -67,7 +65,7 @@
   <rule ref="Generic.PHP.DeprecatedFunctions"/>
   <rule ref="Generic.PHP.DisallowShortOpenTag">
     <!-- Do not run this sniff on .yml files -->
-    <exclude-pattern>*.yml</exclude-pattern>
+    <!-- <exclude-pattern>*.yml</exclude-pattern> -->
   </rule>
   <rule ref="Generic.PHP.LowerCaseKeyword"/>
   <rule ref="Generic.PHP.UpperCaseConstant"/>

--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -63,7 +63,10 @@
   <rule ref="Generic.NamingConventions.ConstructorName"/>
   <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
   <rule ref="Generic.PHP.DeprecatedFunctions"/>
-  <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+  <rule ref="Generic.PHP.DisallowShortOpenTag">
+    <!-- Do not run this sniff on .yml files -->
+    <exclude-pattern>**/*.yml</exclude-pattern>
+  </rule>
   <rule ref="Generic.PHP.LowerCaseKeyword"/>
   <rule ref="Generic.PHP.UpperCaseConstant"/>
   <rule ref="Generic.Strings.UnnecessaryStringConcat">

--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -67,7 +67,7 @@
   <rule ref="Generic.PHP.DeprecatedFunctions"/>
   <rule ref="Generic.PHP.DisallowShortOpenTag">
     <!-- Do not run this sniff on .yml files -->
-    <!-- <exclude-pattern>*.yml</exclude-pattern> -->
+    <exclude-pattern>*.yml</exclude-pattern>
   </rule>
   <rule ref="Generic.PHP.LowerCaseKeyword"/>
   <rule ref="Generic.PHP.UpperCaseConstant"/>

--- a/tests/Drupal/good/good.yml
+++ b/tests/Drupal/good/good.yml
@@ -1,2 +1,3 @@
 top_level:
+  # Generic.PHP.DisallowShortOpenTag should not complain at the short xml tag below.
   data: '<?xml anything ?>\n'

--- a/tests/Drupal/good/good.yml
+++ b/tests/Drupal/good/good.yml
@@ -1,0 +1,2 @@
+top_level:
+  data: '<?xml anything ?>\n'


### PR DESCRIPTION
Do not run Generic.PHP.DisallowShortOpenTag on .yml files
Drupal issue https://www.drupal.org/project/coder/issues/3535411
