### PR TITLE
Fix typo in comment about comments with 2 dots

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -130,7 +130,7 @@
   <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
     <properties>
        <property name="forbiddenCommentPatterns" type="array">
-         <!-- Catch comments ending in 2 dots, bot leave comments ending in 3
+         <!-- Catch comments ending in 2 dots, but leave comments ending in 3
          dots alone. -->
          <element value="/(?&lt;!\.)\.\.(?!\.)$/"/>
        </property>


### PR DESCRIPTION
I assume from the context it was meant to say "but" and not "bot"